### PR TITLE
Implemented the stress test

### DIFF
--- a/fbpcp/entity/cluster_instance.py
+++ b/fbpcp/entity/cluster_instance.py
@@ -24,5 +24,7 @@ class ClusterStatus(Enum):
 class Cluster:
     cluster_arn: str
     cluster_name: str
+    pending_tasks: int
+    running_tasks: int
     status: ClusterStatus = ClusterStatus.UNKNOWN
     tags: Dict[str, str] = field(default_factory=lambda: {})

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -49,7 +49,14 @@ def map_esccluster_to_clusterinstance(cluster: Dict[str, Any]) -> Cluster:
         status = ClusterStatus.UNKNOWN
 
     tags = _convert_aws_tags_to_dict(cluster["tags"], "key", "value")
-    return Cluster(cluster["clusterArn"], cluster["clusterName"], status, tags)
+    return Cluster(
+        cluster_arn=cluster["clusterArn"],
+        cluster_name=cluster["clusterName"],
+        pending_tasks=cluster["pendingTasksCount"],
+        running_tasks=cluster["runningTasksCount"],
+        status=status,
+        tags=tags,
+    )
 
 
 def map_ec2vpc_to_vpcinstance(vpc: Dict[str, Any]) -> Vpc:

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -136,6 +136,7 @@ class TestECSGateway(unittest.TestCase):
         self.gw.client.list_tasks.assert_called()
 
     def test_describe_clusers(self):
+        test_tasks = 100
         client_return_response = {
             "clusters": [
                 {
@@ -148,6 +149,8 @@ class TestECSGateway(unittest.TestCase):
                         },
                     ],
                     "status": "ACTIVE",
+                    "pendingTasksCount": test_tasks,
+                    "runningTasksCount": test_tasks,
                 }
             ]
         }
@@ -161,7 +164,14 @@ class TestECSGateway(unittest.TestCase):
         )
         tags = {self.TEST_CLUSTER_TAG_KEY: self.TEST_CLUSTER_TAG_VALUE}
         expected_clusters = [
-            Cluster(self.TEST_CLUSTER, "cluster_1", ClusterStatus.ACTIVE, tags)
+            Cluster(
+                self.TEST_CLUSTER,
+                "cluster_1",
+                test_tasks,
+                test_tasks,
+                ClusterStatus.ACTIVE,
+                tags,
+            )
         ]
         self.assertEqual(expected_clusters, clusters)
         self.gw.client.describe_clusters.assert_called()

--- a/tests/mapper/test_aws.py
+++ b/tests/mapper/test_aws.py
@@ -111,12 +111,16 @@ class TestAWSMapper(unittest.TestCase):
         tag_key_2 = "tag-key-2"
         tag_value_1 = "tag-value-1"
         tag_value_2 = "tag-value-2"
+        running_tasks = 100
+        pending_tasks = 1
         ecs_cluster_response = {
             "clusters": [
                 {
                     "clusterName": self.TEST_CLUSTER_NAME,
                     "clusterArn": self.TEST_CLUSTER_ARN,
                     "status": "ACTIVE",
+                    "runningTasksCount": running_tasks,
+                    "pendingTasksCount": pending_tasks,
                     "tags": [
                         {
                             "key": tag_key_1,
@@ -132,6 +136,8 @@ class TestAWSMapper(unittest.TestCase):
                     "clusterName": self.TEST_CLUSTER_NAME,
                     "clusterArn": self.TEST_CLUSTER_ARN,
                     "status": "INACTIVE",
+                    "runningTasksCount": running_tasks,
+                    "pendingTasksCount": pending_tasks,
                     "tags": [
                         {
                             "key": tag_key_1,
@@ -143,6 +149,8 @@ class TestAWSMapper(unittest.TestCase):
                     "clusterName": self.TEST_CLUSTER_NAME,
                     "clusterArn": self.TEST_CLUSTER_ARN,
                     "status": "UNKNOWN",
+                    "runningTasksCount": running_tasks,
+                    "pendingTasksCount": pending_tasks,
                     "tags": [
                         {
                             "key": tag_key_1,
@@ -162,18 +170,24 @@ class TestAWSMapper(unittest.TestCase):
             Cluster(
                 self.TEST_CLUSTER_ARN,
                 self.TEST_CLUSTER_NAME,
+                pending_tasks,
+                running_tasks,
                 ClusterStatus.ACTIVE,
                 multi_tag_value_pair,
             ),
             Cluster(
                 self.TEST_CLUSTER_ARN,
                 self.TEST_CLUSTER_NAME,
+                pending_tasks,
+                running_tasks,
                 ClusterStatus.INACTIVE,
                 single_tag_value_pair,
             ),
             Cluster(
                 self.TEST_CLUSTER_ARN,
                 self.TEST_CLUSTER_NAME,
+                pending_tasks,
+                running_tasks,
                 ClusterStatus.UNKNOWN,
                 single_tag_value_pair,
             ),


### PR DESCRIPTION
Summary:
## Sumary
1. Refactored some apis in fbpcs so that stress test can use easily.
2. Refactor the script and implement the stress test to find the capacity
limit.
3. The stress test will try to create 1000 containers (documented limit) and then we call ecs gateway to count how many containers are actually spawn up, which is the capacity limit we are looking for.

## Next
1. Scale the test script to all regions

Differential Revision: D30061078

