### PR TITLE
Use party vs. role for lift in MPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,10 @@ Deprecate container_version parameter for OneDockerService start_container funct
 
 ### Description of changes
 To unblock GTM(Go To Market), we want to rename our project to fbpcp and re-release it to Github and Pypi, the original fbpcs will refer to [Facebook Private Computation Solutions](https://github.com/facebookresearch/fbpcs)
+
+## 0.1.0 -> 0.1.1
+### Types of changes
+*  Breaking change
+
+### Description of changes
+Pass in party instead of role to lift compute stage

--- a/fbpcp/entity/mpc_instance.py
+++ b/fbpcp/entity/mpc_instance.py
@@ -14,7 +14,14 @@ from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.entity.instance_base import InstanceBase
 
 
+# TODO: T96692057 will delete MPCRole, keeping for now so that code doesn't break
+# while fbpmp codebase expects it to exist
 class MPCRole(Enum):
+    SERVER = "SERVER"
+    CLIENT = "CLIENT"
+
+
+class MPCParty(Enum):
     SERVER = "SERVER"
     CLIENT = "CLIENT"
 
@@ -32,7 +39,7 @@ class MPCInstanceStatus(Enum):
 class MPCInstance(InstanceBase):
     instance_id: str
     game_name: str
-    mpc_role: MPCRole
+    mpc_party: MPCParty
     num_workers: int
     server_ips: Optional[List[str]]
     containers: List[ContainerInstance]
@@ -44,17 +51,26 @@ class MPCInstance(InstanceBase):
         cls,
         instance_id: str,
         game_name: str,
-        mpc_role: MPCRole,
         num_workers: int,
+        mpc_role: Optional[MPCRole] = None,
+        mpc_party: Optional[MPCParty] = None,
         server_ips: Optional[List[str]] = None,
         containers: Optional[List[ContainerInstance]] = None,
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
     ) -> "MPCInstance":
+        # TODO: T96692057 will delete mpc_role and make mpc_party required
+        if mpc_party:
+            party = mpc_party
+        elif mpc_role:
+            party = MPCParty.SERVER if mpc_role is MPCRole.SERVER else MPCParty.CLIENT
+        else:
+            raise ValueError("mpc_role or mpc_party should be specified")
+
         return cls(
             instance_id,
             game_name,
-            mpc_role,
+            party,
             num_workers,
             server_ips,
             containers or [],

--- a/fbpcp/service/mpc_game.py
+++ b/fbpcp/service/mpc_game.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 
 from fbpcp.entity.mpc_game_config import MPCGameConfig
-from fbpcp.entity.mpc_instance import MPCRole
+from fbpcp.entity.mpc_instance import MPCParty
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.util.arg_builder import build_cmd_args
 
@@ -27,7 +27,7 @@ class MPCGameService:
     def build_onedocker_args(
         self,
         game_name: str,
-        mpc_role: MPCRole,
+        mpc_party: MPCParty,
         server_ip: Optional[str] = None,
         port: Optional[int] = None,
         **kwargs: object,
@@ -37,7 +37,7 @@ class MPCGameService:
             mpc_game_config.onedocker_package_name,
             self._build_cmd(
                 mpc_game_config=mpc_game_config,
-                mpc_role=mpc_role,
+                mpc_party=mpc_party,
                 server_ip=server_ip,
                 port=port,
                 **kwargs,
@@ -48,14 +48,14 @@ class MPCGameService:
     def _build_cmd(
         self,
         mpc_game_config: MPCGameConfig,
-        mpc_role: MPCRole,
+        mpc_party: MPCParty,
         server_ip: Optional[str] = None,
         port: Optional[int] = None,
         **kwargs: object,
     ) -> str:
         args = self._prepare_args(
             mpc_game_config=mpc_game_config,
-            mpc_role=mpc_role,
+            mpc_party=mpc_party,
             server_ip=server_ip,
             port=port,
             **kwargs,
@@ -65,7 +65,7 @@ class MPCGameService:
     def _prepare_args(
         self,
         mpc_game_config: MPCGameConfig,
-        mpc_role: MPCRole,
+        mpc_party: MPCParty,
         server_ip: Optional[str] = None,
         port: Optional[int] = None,
         **kwargs: object,
@@ -73,14 +73,9 @@ class MPCGameService:
         all_arguments: Dict[str, Any] = {}
 
         # push MPC required arguments to dict all_arguments
-        is_lift_game = (
-            mpc_game_config.game_name == LIFT_AGGREGATOR_GAME_NAME
-            or mpc_game_config.game_name == LIFT_GAME_NAME
-        )  # TODO: T88044929 remove "role" and only support "party" for lift games
-        role_or_party_key = "role" if is_lift_game else "party"
-        all_arguments[role_or_party_key] = 1 if mpc_role == MPCRole.SERVER else 2
+        all_arguments["party"] = 1 if mpc_party == MPCParty.SERVER else 2
 
-        if mpc_role == MPCRole.CLIENT:
+        if mpc_party == MPCParty.CLIENT:
             if server_ip is None:
                 raise ValueError("Client must provide a server ip address.")
             all_arguments["server_ip"] = server_ip

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.1.0",
+    version="0.1.1",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",

--- a/tests/repository/test_instance_local.py
+++ b/tests/repository/test_instance_local.py
@@ -9,13 +9,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, MagicMock, patch
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.repository.instance_local import LocalInstanceRepository
 
 TEST_BASE_DIR = Path("./")
 TEST_INSTANCE_ID = "test-instance-id"
 TEST_GAME_NAME = "lift"
-TEST_MPC_ROLE = MPCRole.SERVER
+TEST_MPC_PARTY = MPCParty.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
 TEST_GAME_ARGS = [{}]
@@ -28,7 +28,7 @@ class TestLocalInstanceRepository(unittest.TestCase):
         self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_PARTY,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,

--- a/tests/repository/test_instance_s3.py
+++ b/tests/repository/test_instance_s3.py
@@ -8,7 +8,7 @@ import unittest
 import uuid
 from unittest.mock import MagicMock
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.repository.instance_s3 import S3InstanceRepository
 from fbpcp.service.storage_s3 import S3StorageService
 
@@ -17,7 +17,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     TEST_BASE_DIR = "./"
     TEST_INSTANCE_ID = str(uuid.uuid4())
     TEST_GAME_NAME = "lift"
-    TEST_MPC_ROLE = MPCRole.SERVER
+    TEST_MPC_PARTY = MPCParty.SERVER
     TEST_NUM_WORKERS = 1
     TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
     TEST_GAME_ARGS = [{}]
@@ -30,7 +30,7 @@ class TestS3InstanceRepository(unittest.TestCase):
         self.mpc_instance = MPCInstance.create_instance(
             instance_id=self.TEST_INSTANCE_ID,
             game_name=self.TEST_GAME_NAME,
-            mpc_role=self.TEST_MPC_ROLE,
+            mpc_party=self.TEST_MPC_PARTY,
             num_workers=self.TEST_NUM_WORKERS,
             server_ips=self.TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,

--- a/tests/repository/test_mpc_instance_local.py
+++ b/tests/repository/test_mpc_instance_local.py
@@ -9,13 +9,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, MagicMock, patch
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.repository.mpc_instance_local import LocalMPCInstanceRepository
 
 TEST_BASE_DIR = Path("./")
 TEST_INSTANCE_ID = "test-instance-id"
 TEST_GAME_NAME = "lift"
-TEST_MPC_ROLE = MPCRole.SERVER
+TEST_MPC_PARTY = MPCParty.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
 TEST_GAME_ARGS = [{}]
@@ -28,7 +28,7 @@ class TestLocalMPCInstanceRepository(unittest.TestCase):
         self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_PARTY,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,

--- a/tests/repository/test_mpc_instance_s3.py
+++ b/tests/repository/test_mpc_instance_s3.py
@@ -8,14 +8,14 @@ import unittest
 import uuid
 from unittest.mock import MagicMock
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.repository.mpc_instance_s3 import S3MPCInstanceRepository
 from fbpcp.service.storage_s3 import S3StorageService
 
 TEST_BASE_DIR = "./"
 TEST_INSTANCE_ID = str(uuid.uuid4())
 TEST_GAME_NAME = "lift"
-TEST_MPC_ROLE = MPCRole.SERVER
+TEST_MPC_PARTY = MPCParty.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
 TEST_GAME_ARGS = [{}]
@@ -30,7 +30,7 @@ class TestS3InstanceRepository(unittest.TestCase):
         self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_PARTY,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -8,13 +8,13 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.service.mpc import MPCService
 
 
 TEST_INSTANCE_ID = "123"
 TEST_GAME_NAME = "lift"
-TEST_MPC_ROLE = MPCRole.SERVER
+TEST_MPC_ROLE = MPCParty.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
 TEST_INPUT_ARGS = "test_input_file"
@@ -63,7 +63,7 @@ class TestMPCService(unittest.TestCase):
         return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_ROLE,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
@@ -75,7 +75,7 @@ class TestMPCService(unittest.TestCase):
         return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_ROLE,
             num_workers=TEST_NUM_WORKERS,
             status=MPCInstanceStatus.CREATED,
             server_ips=TEST_SERVER_IPS,
@@ -87,7 +87,7 @@ class TestMPCService(unittest.TestCase):
         return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=MPCRole.CLIENT,
+            mpc_party=MPCParty.CLIENT,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
@@ -101,7 +101,7 @@ class TestMPCService(unittest.TestCase):
         ):
             await self.mpc_service._spin_up_containers_onedocker(
                 game_name=TEST_GAME_NAME,
-                mpc_role=MPCRole.SERVER,
+                mpc_party=MPCParty.SERVER,
                 num_containers=TEST_NUM_WORKERS,
                 game_args=[],
             )
@@ -112,7 +112,7 @@ class TestMPCService(unittest.TestCase):
         ):
             await self.mpc_service._spin_up_containers_onedocker(
                 game_name=TEST_GAME_NAME,
-                mpc_role=MPCRole.CLIENT,
+                mpc_party=MPCParty.CLIENT,
                 num_containers=TEST_NUM_WORKERS,
                 ip_addresses=TEST_SERVER_IPS,
             )
@@ -121,7 +121,7 @@ class TestMPCService(unittest.TestCase):
         self.mpc_service.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_ROLE,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             game_args=GAME_ARGS,
@@ -136,7 +136,7 @@ class TestMPCService(unittest.TestCase):
         self.mpc_service.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
-            mpc_role=TEST_MPC_ROLE,
+            mpc_party=TEST_MPC_ROLE,
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             game_args=GAME_ARGS,

--- a/tests/service/test_mpc_game.py
+++ b/tests/service/test_mpc_game.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, MagicMock
 
 from fbpcp.entity.mpc_game_config import MPCGameArgument
 from fbpcp.entity.mpc_game_config import MPCGameConfig
-from fbpcp.entity.mpc_instance import MPCRole
+from fbpcp.entity.mpc_instance import MPCParty
 from fbpcp.service.mpc_game import MPCGameService
 
 INPUT_DIRECTORY = "input_directory"
@@ -58,7 +58,7 @@ class TestMPCGameService(unittest.TestCase):
         self.assertEqual(
             self.mpc_game_svc._prepare_args(
                 mpc_game_config=self.mpc_game_config,
-                mpc_role=MPCRole.CLIENT,
+                mpc_party=MPCParty.CLIENT,
                 server_ip="192.0.2.0",
                 port=12345,
                 input_filenames=INPUT_PATH_1,
@@ -83,7 +83,7 @@ class TestMPCGameService(unittest.TestCase):
         self.assertEqual(
             self.mpc_game_svc._prepare_args(
                 mpc_game_config=self.mpc_game_config,
-                mpc_role=MPCRole.SERVER,
+                mpc_party=MPCParty.SERVER,
                 input_filenames=INPUT_PATH_1,
                 input_directory=INPUT_DIRECTORY,
                 output_filenames=OUTPUT_PATH_1,
@@ -106,7 +106,7 @@ class TestMPCGameService(unittest.TestCase):
         ):
             self.mpc_game_svc._prepare_args(
                 mpc_game_config=self.mpc_game_config,
-                mpc_role=MPCRole.SERVER,
+                mpc_party=MPCParty.SERVER,
                 output_file=OUTPUT_PATH_1,
             )
 
@@ -114,7 +114,7 @@ class TestMPCGameService(unittest.TestCase):
         self.assertEqual(
             self.mpc_game_svc._build_cmd(
                 mpc_game_config=self.mpc_game_config,
-                mpc_role=MPCRole.CLIENT,
+                mpc_party=MPCParty.CLIENT,
                 server_ip="192.0.2.0",
                 port=12345,
                 input_filenames=INPUT_PATH_1,
@@ -167,7 +167,7 @@ class TestMPCGameService(unittest.TestCase):
             self.assertEqual(
                 self.mpc_game_svc.build_onedocker_args(
                     game_name="game",
-                    mpc_role=MPCRole.SERVER,
+                    mpc_party=MPCParty.SERVER,
                     **game_arg,
                 ),
                 expected_argument,


### PR DESCRIPTION
Summary:
**What:** Rename MPC role flag to party for the lift compute game

**Why:** This is important for de-coupling pl/pa from pcs.  Now that lift uses the generic shard aggregator, we would also like to be consistent in our party/role naming, since MPC service is used to spin up containers for both the compute and aggregate stages.

Differential Revision: D30231350

