### PR TITLE
Deprecate MPCRole in fbpcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,10 @@ To unblock GTM(Go To Market), we want to rename our project to fbpcp and re-rele
 
 ### Description of changes
 Pass in party instead of role to lift compute stage
+
+## 0.1.1 -> 0.1.2
+### Types of changes
+*  Breaking change
+
+### Description of changes
+Deprecate MPCRole

--- a/fbpcp/entity/mpc_instance.py
+++ b/fbpcp/entity/mpc_instance.py
@@ -14,13 +14,6 @@ from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.entity.instance_base import InstanceBase
 
 
-# TODO: T96692057 will delete MPCRole, keeping for now so that code doesn't break
-# while fbpmp codebase expects it to exist
-class MPCRole(Enum):
-    SERVER = "SERVER"
-    CLIENT = "CLIENT"
-
-
 class MPCParty(Enum):
     SERVER = "SERVER"
     CLIENT = "CLIENT"
@@ -51,26 +44,17 @@ class MPCInstance(InstanceBase):
         cls,
         instance_id: str,
         game_name: str,
+        mpc_party: MPCParty,
         num_workers: int,
-        mpc_role: Optional[MPCRole] = None,
-        mpc_party: Optional[MPCParty] = None,
         server_ips: Optional[List[str]] = None,
         containers: Optional[List[ContainerInstance]] = None,
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
     ) -> "MPCInstance":
-        # TODO: T96692057 will delete mpc_role and make mpc_party required
-        if mpc_party:
-            party = mpc_party
-        elif mpc_role:
-            party = MPCParty.SERVER if mpc_role is MPCRole.SERVER else MPCParty.CLIENT
-        else:
-            raise ValueError("mpc_role or mpc_party should be specified")
-
         return cls(
             instance_id,
             game_name,
-            party,
+            mpc_party,
             num_workers,
             server_ips,
             containers or [],

--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty, MPCRole
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
 from fbpcp.service.mpc_game import MPCGameService
@@ -107,20 +107,17 @@ class MPCService:
         self,
         instance_id: str,
         game_name: str,
+        mpc_party: MPCParty,
         num_workers: int,
-        mpc_role: Optional[MPCRole] = None,
-        mpc_party: Optional[MPCParty] = None,
         server_ips: Optional[List[str]] = None,
         game_args: Optional[List[Dict[str, Any]]] = None,
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
-        # TODO: T96692057 will delete mpc_role and make mpc_party required
         instance = MPCInstance.create_instance(
             instance_id=instance_id,
             game_name=game_name,
             mpc_party=mpc_party,
-            mpc_role=mpc_role,
             num_workers=num_workers,
             server_ips=server_ips,
             status=MPCInstanceStatus.CREATED,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.1.1",
+    version="0.1.2",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
**What:** Deprecate MPCRole from MPC instance in fbpcp

**Why:** Migrating MPCRole --> MPCParty is important for de-coupling pl/pa from pcs.  Now that lift uses the generic shard aggregator, we would also like to be consistent in our party/role naming, since MPC service is used to spin up containers for both the compute and aggregate stages.  In earlier diffs we added mpc_party in addition to mpc_role in order to avoid making a breaking change before fbpmp code could be changed, and in this diff we officially deprecate MPCRole

Differential Revision: D30305015

