### PR TITLE
OSS onedocker package repository

### DIFF
--- a/onedocker/entity/__init__.py
+++ b/onedocker/entity/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/entity/package_info.py
+++ b/onedocker/entity/package_info.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PackageInfo:
+    package_name: str
+    version: str
+    last_modified: str
+    package_size: int

--- a/onedocker/repository/__init__.py
+++ b/onedocker/repository/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/repository/onedocker_package.py
+++ b/onedocker/repository/onedocker_package.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import List
+
+from fbpcp.service.storage import StorageService
+from onedocker.entity.package_info import PackageInfo
+
+
+class OneDockerPackageRepository:
+    def __init__(self, storage_svc: StorageService, repository_path: str) -> None:
+        self.storage_svc = storage_svc
+        self.repository_path = repository_path
+
+    def _build_package_path(self, package_name: str, version: str) -> str:
+        return f"{self.repository_path}{package_name}/{version}/{package_name.split('/')[-1]}"
+
+    def upload(self, package_name: str, version: str, source: str) -> None:
+        package_path = self._build_package_path(package_name, version)
+        self.storage_svc.copy(source, package_path)
+
+    def download(self, package_name: str, version: str, destination: str) -> None:
+        package_path = self._build_package_path(package_name, version)
+        self.storage_svc.copy(package_path, destination)
+
+    def get_package_versions(
+        self,
+        package_name: str,
+    ) -> List[str]:
+        package_parent_path = f"{self.repository_path}{package_name}/"
+        return self.storage_svc.list_folders(package_parent_path)
+
+    def get_package_info(self, package_name: str, version: str) -> PackageInfo:
+        package_path = self._build_package_path(package_name, version)
+
+        if not self.storage_svc.file_exists(package_path):
+            raise ValueError(
+                f"Package {package_name}, version {version} not found in repository"
+            )
+
+        file_info = self.storage_svc.get_file_info(package_path)
+        return PackageInfo(
+            package_name=package_name,
+            version=version,
+            last_modified=file_info.last_modified,
+            package_size=file_info.file_size,
+        )


### PR DESCRIPTION
Summary:
We want to oss onedocker package repository so our E2E scripts can upload binaries to S3 through onedocker_cli instead of aws cli, which depends on onedocker package repository.

1. Moved onedocker package repository to oss folder.
2. Re-org the oss-d onedocker structure.
* moved onedocker/common -> onedocker/lib/common
* Add entity and repository under onedocker/lib

Differential Revision: D30373547

