### PR TITLE
Release fbpcp with onedocker_cli added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,10 @@ Pass in party instead of role to lift compute stage
 
 ### Description of changes
 Deprecate MPCRole
+
+## 0.1.2 -> 0.1.3
+### Types of changes
+*  New feature (non-breaking change which adds functionality)
+
+### Description of changes
+Add onodocker_cli that can be used to upload/show onedocker repository package, as long as test/stop containers.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.1.2",
+    version="0.1.3",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: This is a follow up diff for D30390212 to release the fbpcp with onedocker_cli

Differential Revision: D30407742

