### PR TITLE
Release fbpcp-0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,10 @@ Deprecate MPCRole
 
 ### Description of changes
 Add onodocker_cli that can be used to upload/show onedocker repository package, as long as test/stop containers.
+
+## 0.1.3 -> 0.1.4
+### Types of changes
+*  New feature (non-breaking change which adds functionality)
+
+### Description of changes
+Add support for single-word OneDocker package in OneDocker Runner

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,10 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.1.3",
+    version="0.1.4",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",
-    # TODO refactor this once repo renaming is done
     url="https://github.com/facebookresearch/fbpcp",
     install_requires=install_requires,
     packages=find_packages(),


### PR DESCRIPTION
Summary:
D30518906 (https://github.com/facebookresearch/fbpcp/commit/0798b027ed78f93122172f1edff8b27f049556cf) added support for single-word OneDocker package in OneDocker Runner.

This diff is to release fbpcp so pce can install 0.1.4

Differential Revision: D30562665

