### PR TITLE
Add task definition entity

### DIFF
--- a/fbpcp/entity/iam.py
+++ b/fbpcp/entity/iam.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Policy:
+    name: str
+    resource_name: str
+    policy_json: str
+    permissions: List[str]
+
+
+@dataclass
+class Role:
+    name: str
+    resource_name: str
+    assume_role_policy_json: str
+    attached_policies: List[Policy]
+    tags: Dict[str, str] = field(default_factory=lambda: {})

--- a/fbpcp/entity/task_definition.py
+++ b/fbpcp/entity/task_definition.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from fbpcp.entity.iam import Role
+
+
+@dataclass
+class TaskDefinition:
+    name: str
+    image: str
+    cpu: int
+    memory: int
+    entry_point: List[str]
+    environment: List[str]
+    task_role: Role
+    execution_role: Role
+    tags: Dict[str, str] = field(default_factory=lambda: {})


### PR DESCRIPTION
Summary:
Add `Task_definition` entity in fbpcp. Map to aws https://fburl.com/3f3a5fw8.
Example output: P453902160

Differential Revision: D30633514

