### PR TITLE
Non-blocking APIs for onedocker service and container service

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -45,15 +45,6 @@ class ContainerService(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create_instances_async(
-        self,
-        container_definition: str,
-        cmds: List[str],
-        env_vars: Optional[Dict[str, str]] = None,
-    ) -> List[ContainerInstance]:
-        pass
-
-    @abc.abstractmethod
     def get_instance(self, instance_id: str) -> ContainerInstance:
         pass
 

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -7,12 +7,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.error.pcp import PcpError
-from fbpcp.service.container_aws import (
-    ContainerInstance,
-    ContainerInstanceStatus,
-    AWSContainerService,
-)
+from fbpcp.service.container_aws import AWSContainerService
 
 TEST_INSTANCE_ID_1 = "test-instance-id-1"
 TEST_INSTANCE_ID_2 = "test-instance-id-2"
@@ -53,33 +50,6 @@ class TestAWSContainerService(unittest.TestCase):
 
         cmd_list = ["test_cmd", "test_cmd-1"]
         container_instances = self.container_svc.create_instances(
-            TEST_CONTAINER_DEFNITION, cmd_list
-        )
-        self.assertEqual(container_instances, created_instances)
-        self.assertEqual(
-            self.container_svc.ecs_gateway.run_task.call_count, len(created_instances)
-        )
-
-    async def test_create_instances_async(self):
-        created_instances = [
-            ContainerInstance(
-                TEST_INSTANCE_ID_1,
-                TEST_IP_ADDRESS,
-                ContainerInstanceStatus.STARTED,
-            ),
-            ContainerInstance(
-                TEST_INSTANCE_ID_2,
-                TEST_IP_ADDRESS,
-                ContainerInstanceStatus.STARTED,
-            ),
-        ]
-
-        self.container_svc.ecs_gateway.run_task = MagicMock(
-            side_effect=created_instances
-        )
-
-        cmd_list = ["test_cmd", "test_cmd-1"]
-        container_instances = await self.container_svc.create_instances_async(
             TEST_CONTAINER_DEFNITION, cmd_list
         )
         self.assertEqual(container_instances, created_instances)

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
@@ -167,7 +167,7 @@ class TestMPCService(unittest.TestCase):
                 ContainerInstanceStatus.STARTED,
             )
         ]
-        self.mpc_service.container_svc.create_instances_async = AsyncMock(
+        self.mpc_service.container_svc.create_instances = MagicMock(
             return_value=created_instances
         )
         built_onedocker_args = ("private_lift/lift", "test one docker arguments")

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -6,7 +6,7 @@
 
 import unittest
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch, ANY
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.error.pcp import PcpError
@@ -29,7 +29,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             "192.0.2.0",
             ContainerInstanceStatus.STARTED,
         )
-        self.container_svc.create_instances_async = AsyncMock(
+        self.container_svc.create_instances = MagicMock(
             return_value=[mocked_container_info]
         )
         returned_container_info = self.onedocker_svc.start_container(
@@ -52,7 +52,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 ContainerInstanceStatus.STARTED,
             ),
         ]
-        self.container_svc.create_instances_async = AsyncMock(
+        self.container_svc.create_instances = MagicMock(
             return_value=mocked_container_info
         )
         returned_container_info = self.onedocker_svc.start_containers(
@@ -106,7 +106,7 @@ class TestOneDockerServiceAsync(IsolatedAsyncioTestCase):
             "192.0.2.0",
             ContainerInstanceStatus.STARTED,
         )
-        self.container_svc.create_instances_async = AsyncMock(
+        self.container_svc.create_instances_async = MagicMock(
             return_value=[mocked_container_info]
         )
 


### PR DESCRIPTION
Summary:
## Context
Currently start_containers in onedocker service will block users and return the result when all containers are running. However, PCE service doesn't want to wait for all containers to be running, so we want to change the blocking api to non-blocking api.

But we still want to keep the waiting logic in onedocker service otherwise the pending containers won't have IP addresses.

## Summary

For OneDocker Service
1. start_container and start_containers will immediately return once we got the response from boto3.
2. start_containers_async will stay same.

For container service
1. create_instance and create_instances will immediately return
2. We will delete create_instances_async

Fix some dependencies.

Differential Revision: D30648608

