### PR TITLE
Modify gateway function to get vpc by tags

### DIFF
--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -30,8 +30,16 @@ class EC2Gateway(AWSGateway):
         self.client = boto3.client("ec2", region_name=self.region, **self.config)
 
     @error_handler
-    def describe_vpcs(self, vpc_ids: List[str]) -> List[Vpc]:
-        response = self.client.describe_vpcs(VpcIds=vpc_ids)
+    def describe_vpcs(
+        self,
+        vpc_ids: Optional[List[str]] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[Vpc]:
+        if vpc_ids is None:
+            vpc_ids = []
+        tags_dict = prepare_tags(tags) if tags else {}
+        filters = convert_dict_to_list(tags_dict, "Name", "Values")
+        response = self.client.describe_vpcs(VpcIds=vpc_ids, Filters=filters)
         return [map_ec2vpc_to_vpcinstance(vpc) for vpc in response["Vpcs"]]
 
     @error_handler

--- a/tests/util/test_aws.py
+++ b/tests/util/test_aws.py
@@ -25,6 +25,7 @@ class TestAWSUtil(unittest.TestCase):
         self.assertEqual(
             expected_list, convert_dict_to_list(TEST_DICT, "Name", "Values")
         )
+        self.assertEqual([], convert_dict_to_list({}, "Name", "Values"))
 
     def test_convert_list_dict(self):
         self.assertEqual(TEST_DICT, convert_list_to_dict(TEST_LIST, "Name", "Value"))


### PR DESCRIPTION
Summary:
What: Support describe aws vpc by tags

Why: The PCE service will use a PCE ID as a tag to query all resources under the PCE.

Differential Revision: D30718680

