### PR TITLE
Add cidr block for vpc instance

### DIFF
--- a/fbpcp/entity/vpc_instance.py
+++ b/fbpcp/entity/vpc_instance.py
@@ -24,6 +24,7 @@ class VpcState(Enum):
 @dataclass
 class Vpc:
     vpc_id: str
+    cidr: str
     state: VpcState = VpcState.UNKNOWN
     firewall_rulesets: List[FirewallRuleset] = field(default_factory=list)
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -30,8 +30,16 @@ class EC2Gateway(AWSGateway):
         self.client = boto3.client("ec2", region_name=self.region, **self.config)
 
     @error_handler
-    def describe_vpcs(self, vpc_ids: List[str]) -> List[Vpc]:
-        response = self.client.describe_vpcs(VpcIds=vpc_ids)
+    def describe_vpcs(
+        self,
+        vpc_ids: Optional[List[str]] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[Vpc]:
+        if vpc_ids is None:
+            vpc_ids = []
+        tags_dict = prepare_tags(tags) if tags else {}
+        filters = convert_dict_to_list(tags_dict, "Name", "Values")
+        response = self.client.describe_vpcs(VpcIds=vpc_ids, Filters=filters)
         return [map_ec2vpc_to_vpcinstance(vpc) for vpc in response["Vpcs"]]
 
     @error_handler

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -69,11 +69,12 @@ def map_ec2vpc_to_vpcinstance(vpc: Dict[str, Any]) -> Vpc:
         state = VpcState.UNKNOWN
 
     vpc_id = vpc["VpcId"]
+    cidr_block = vpc["CidrBlock"]
     # some vpc instances don't have any tags
     tags = convert_list_to_dict(vpc["Tags"], "Key", "Value") if "Tags" in vpc else {}
 
     # TODO add implementation to get the firewall_ruleset
-    return Vpc(vpc_id, state, [], tags)
+    return Vpc(vpc_id, cidr_block, state, [], tags)
 
 
 def map_ec2subnet_to_subnet(subnet: Dict[str, Any]) -> Subnet:

--- a/tests/gateway/test_ec2.py
+++ b/tests/gateway/test_ec2.py
@@ -16,6 +16,7 @@ TEST_ACCESS_KEY_ID = "test-access-key-id"
 TEST_ACCESS_KEY_DATA = "test-access-key-data"
 TEST_VPC_TAG_KEY = "test-vpc-tag-key"
 TEST_VPC_TAG_VALUE = "test-vpc-tag-value"
+TEST_CIDR_BLOCK = "10.1.0.0/16"
 REGION = "us-west-2"
 
 
@@ -30,6 +31,7 @@ class TestEC2Gateway(unittest.TestCase):
             "Vpcs": [
                 {
                     "State": "UNKNOWN",
+                    "CidrBlock": TEST_CIDR_BLOCK,
                     "VpcId": TEST_VPC_ID,
                     "Tags": [
                         {
@@ -46,6 +48,7 @@ class TestEC2Gateway(unittest.TestCase):
         expected_vpcs = [
             Vpc(
                 TEST_VPC_ID,
+                TEST_CIDR_BLOCK,
                 VpcState.UNKNOWN,
                 [],
                 tags,

--- a/tests/util/test_aws.py
+++ b/tests/util/test_aws.py
@@ -25,6 +25,7 @@ class TestAWSUtil(unittest.TestCase):
         self.assertEqual(
             expected_list, convert_dict_to_list(TEST_DICT, "Name", "Values")
         )
+        self.assertEqual([], convert_dict_to_list({}, "Name", "Values"))
 
     def test_convert_list_dict(self):
         self.assertEqual(TEST_DICT, convert_list_to_dict(TEST_LIST, "Name", "Value"))


### PR DESCRIPTION
Summary:
What: Add cidr block for vpc instance

Why: We want to validate if the cidr is in a private ip range.

Differential Revision: D30734715

