### PR TITLE
Add the function to describe the firewall ruleset

### DIFF
--- a/fbpcp/entity/firewall_ruleset.py
+++ b/fbpcp/entity/firewall_ruleset.py
@@ -20,6 +20,7 @@ class FirewallRule:
 @dataclass
 class FirewallRuleset:
     id: str
+    vpc_id: str
     ingress: List[FirewallRule]
     egress: List[FirewallRule]
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/entity/route_table.py
+++ b/fbpcp/entity/route_table.py
@@ -16,6 +16,11 @@ class RouteTargetType(Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
+class RouteState(Enum):
+    UNKNOWN = "UNKNOWN"
+    ACTIVE = "ACTIVE"
+
+
 @dataclass
 class RouteTarget:
     route_target_id: str
@@ -26,6 +31,7 @@ class RouteTarget:
 class Route:
     destination_cidr_block: str
     route_target: RouteTarget
+    state: RouteState
 
 
 @dataclass

--- a/fbpcp/entity/vpc_instance.py
+++ b/fbpcp/entity/vpc_instance.py
@@ -8,10 +8,9 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+from typing import Dict
 
 from dataclasses_json import dataclass_json
-from fbpcp.entity.firewall_ruleset import FirewallRuleset
 
 
 class VpcState(Enum):
@@ -26,5 +25,4 @@ class Vpc:
     vpc_id: str
     cidr: str
     state: VpcState = VpcState.UNKNOWN
-    firewall_rulesets: List[FirewallRuleset] = field(default_factory=list)
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Dict, Any
 
 import boto3
 from fbpcp.decorator.error_handler import error_handler
+from fbpcp.entity.firewall_ruleset import FirewallRuleset
 from fbpcp.entity.route_table import RouteTable
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc
@@ -18,6 +19,7 @@ from fbpcp.mapper.aws import (
     map_ec2vpc_to_vpcinstance,
     map_ec2subnet_to_subnet,
     map_ec2routetable_to_routetable,
+    map_ec2securitygroup_to_firewallruleset,
 )
 from fbpcp.util.aws import convert_dict_to_list, prepare_tags
 
@@ -87,4 +89,22 @@ class EC2Gateway(AWSGateway):
         return [
             map_ec2routetable_to_routetable(route_table)
             for route_table in response["RouteTables"]
+        ]
+
+    @error_handler
+    def describe_security_groups(
+        self,
+        vpc_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[FirewallRuleset]:
+        vpc_dict = {"vpc-id": vpc_id} if vpc_id else {}
+        tags_dict = prepare_tags(tags) if tags else {}
+        filter_dict = {**vpc_dict, **tags_dict}
+        filters = (
+            convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+        )
+        response = self.client.describe_security_groups(Filters=filters)
+        return [
+            map_ec2securitygroup_to_firewallruleset(security_group)
+            for security_group in response["SecurityGroups"]
         ]

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -10,10 +10,15 @@ from typing import List, Optional, Dict, Any
 
 import boto3
 from fbpcp.decorator.error_handler import error_handler
+from fbpcp.entity.route_table import RouteTable
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc
 from fbpcp.gateway.aws import AWSGateway
-from fbpcp.mapper.aws import map_ec2vpc_to_vpcinstance, map_ec2subnet_to_subnet
+from fbpcp.mapper.aws import (
+    map_ec2vpc_to_vpcinstance,
+    map_ec2subnet_to_subnet,
+    map_ec2routetable_to_routetable,
+)
 from fbpcp.util.aws import convert_dict_to_list, prepare_tags
 
 
@@ -65,3 +70,21 @@ class EC2Gateway(AWSGateway):
         )
         response = self.client.describe_subnets(Filters=filters)
         return [map_ec2subnet_to_subnet(subnet) for subnet in response["Subnets"]]
+
+    @error_handler
+    def describe_route_tables(
+        self,
+        vpc_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[RouteTable]:
+        vpc_dict = {"vpc-id": vpc_id} if vpc_id else {}
+        tags_dict = prepare_tags(tags) if tags else {}
+        filter_dict = {**vpc_dict, **tags_dict}
+        filters = (
+            convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+        )
+        response = self.client.describe_route_tables(Filters=filters)
+        return [
+            map_ec2routetable_to_routetable(route_table)
+            for route_table in response["RouteTables"]
+        ]


### PR DESCRIPTION
Summary:
**What:**
1. Add gateway to describe the security groups from aws.
2. Add mapper function to map the aws response to pcp entity.
3. Add integration test and unit test.
4. Move the `firewall_rulesets` out of the VPC

**Why:**
1. I don't think for every time the user fetches the VPC, the user also wants to fetch the `firewall_rulesets` at the same time.
2. Since boto3 describe_vpcs method will not return the security groups information, we have to make a second API call to describe the security groups.

Combine the above two reasons, I decide to move the `firewall_rulesets` out of the VPC instance entity.

Differential Revision: D30795415

