### PR TITLE
Add function to get the route tables

### DIFF
--- a/fbpcp/entity/route_table.py
+++ b/fbpcp/entity/route_table.py
@@ -16,6 +16,11 @@ class RouteTargetType(Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
+class RouteState(Enum):
+    UNKNOWN = "UNKNOWN"
+    ACTIVE = "ACTIVE"
+
+
 @dataclass
 class RouteTarget:
     route_target_id: str
@@ -26,6 +31,7 @@ class RouteTarget:
 class Route:
     destination_cidr_block: str
     route_target: RouteTarget
+    state: RouteState
 
 
 @dataclass

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -10,10 +10,15 @@ from typing import List, Optional, Dict, Any
 
 import boto3
 from fbpcp.decorator.error_handler import error_handler
+from fbpcp.entity.route_table import RouteTable
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc
 from fbpcp.gateway.aws import AWSGateway
-from fbpcp.mapper.aws import map_ec2vpc_to_vpcinstance, map_ec2subnet_to_subnet
+from fbpcp.mapper.aws import (
+    map_ec2vpc_to_vpcinstance,
+    map_ec2subnet_to_subnet,
+    map_ec2routetable_to_routetable,
+)
 from fbpcp.util.aws import convert_dict_to_list, prepare_tags
 
 
@@ -65,3 +70,21 @@ class EC2Gateway(AWSGateway):
         )
         response = self.client.describe_subnets(Filters=filters)
         return [map_ec2subnet_to_subnet(subnet) for subnet in response["Subnets"]]
+
+    @error_handler
+    def describe_route_tables(
+        self,
+        vpc_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[RouteTable]:
+        vpc_dict = {"vpc-id": vpc_id} if vpc_id else {}
+        tags_dict = prepare_tags(tags) if tags else {}
+        filter_dict = {**vpc_dict, **tags_dict}
+        filters = (
+            convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+        )
+        response = self.client.describe_route_tables(Filters=filters)
+        return [
+            map_ec2routetable_to_routetable(route_table)
+            for route_table in response["RouteTables"]
+        ]


### PR DESCRIPTION
Summary:
**What:**
1. Add route status for learn the current of the route.
1) Add gateway to describe the route tables from aws.
2) Add mapper function to map the aws response to pcp entity.
3) Add integration test and unit test.

Differential Revision: D30794647

