### PR TITLE
Add function to get the container definition

### DIFF
--- a/fbpcp/entity/container_definition.py
+++ b/fbpcp/entity/container_definition.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class ContainerDefinition:
+    id: str
+    image: str
+    cpu: int
+    memory: int
+    entry_point: List[str]
+    environment: Dict[str, str]
+    task_role_id: str
+    tags: Dict[str, str] = field(default_factory=lambda: {})

--- a/fbpcp/entity/firewall_ruleset.py
+++ b/fbpcp/entity/firewall_ruleset.py
@@ -20,6 +20,7 @@ class FirewallRule:
 @dataclass
 class FirewallRuleset:
     id: str
+    vpc_id: str
     ingress: List[FirewallRule]
     egress: List[FirewallRule]
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/entity/route_table.py
+++ b/fbpcp/entity/route_table.py
@@ -16,6 +16,11 @@ class RouteTargetType(Enum):
     VPC_PEERING = "VPC_PEERING"
 
 
+class RouteState(Enum):
+    UNKNOWN = "UNKNOWN"
+    ACTIVE = "ACTIVE"
+
+
 @dataclass
 class RouteTarget:
     route_target_id: str
@@ -26,6 +31,7 @@ class RouteTarget:
 class Route:
     destination_cidr_block: str
     route_target: RouteTarget
+    state: RouteState
 
 
 @dataclass

--- a/fbpcp/entity/vpc_instance.py
+++ b/fbpcp/entity/vpc_instance.py
@@ -8,10 +8,9 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+from typing import Dict
 
 from dataclasses_json import dataclass_json
-from fbpcp.entity.firewall_ruleset import FirewallRuleset
 
 
 class VpcState(Enum):
@@ -26,5 +25,4 @@ class Vpc:
     vpc_id: str
     cidr: str
     state: VpcState = VpcState.UNKNOWN
-    firewall_rulesets: List[FirewallRuleset] = field(default_factory=list)
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Dict, Any
 
 import boto3
 from fbpcp.decorator.error_handler import error_handler
+from fbpcp.entity.firewall_ruleset import FirewallRuleset
 from fbpcp.entity.route_table import RouteTable
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc
@@ -18,6 +19,7 @@ from fbpcp.mapper.aws import (
     map_ec2vpc_to_vpcinstance,
     map_ec2subnet_to_subnet,
     map_ec2routetable_to_routetable,
+    map_ec2securitygroup_to_firewallruleset,
 )
 from fbpcp.util.aws import convert_dict_to_list, prepare_tags
 
@@ -87,4 +89,22 @@ class EC2Gateway(AWSGateway):
         return [
             map_ec2routetable_to_routetable(route_table)
             for route_table in response["RouteTables"]
+        ]
+
+    @error_handler
+    def describe_security_groups(
+        self,
+        vpc_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[FirewallRuleset]:
+        vpc_dict = {"vpc-id": vpc_id} if vpc_id else {}
+        tags_dict = prepare_tags(tags) if tags else {}
+        filter_dict = {**vpc_dict, **tags_dict}
+        filters = (
+            convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+        )
+        response = self.client.describe_security_groups(Filters=filters)
+        return [
+            map_ec2securitygroup_to_firewallruleset(security_group)
+            for security_group in response["SecurityGroups"]
         ]

--- a/fbpcp/gateway/ec2.py
+++ b/fbpcp/gateway/ec2.py
@@ -10,10 +10,15 @@ from typing import List, Optional, Dict, Any
 
 import boto3
 from fbpcp.decorator.error_handler import error_handler
+from fbpcp.entity.route_table import RouteTable
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc
 from fbpcp.gateway.aws import AWSGateway
-from fbpcp.mapper.aws import map_ec2vpc_to_vpcinstance, map_ec2subnet_to_subnet
+from fbpcp.mapper.aws import (
+    map_ec2vpc_to_vpcinstance,
+    map_ec2subnet_to_subnet,
+    map_ec2routetable_to_routetable,
+)
 from fbpcp.util.aws import convert_dict_to_list, prepare_tags
 
 
@@ -65,3 +70,21 @@ class EC2Gateway(AWSGateway):
         )
         response = self.client.describe_subnets(Filters=filters)
         return [map_ec2subnet_to_subnet(subnet) for subnet in response["Subnets"]]
+
+    @error_handler
+    def describe_route_tables(
+        self,
+        vpc_id: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[RouteTable]:
+        vpc_dict = {"vpc-id": vpc_id} if vpc_id else {}
+        tags_dict = prepare_tags(tags) if tags else {}
+        filter_dict = {**vpc_dict, **tags_dict}
+        filters = (
+            convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+        )
+        response = self.client.describe_route_tables(Filters=filters)
+        return [
+            map_ec2routetable_to_routetable(route_table)
+            for route_table in response["RouteTables"]
+        ]

--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -12,12 +12,14 @@ import boto3
 from fbpcp.decorator.error_handler import error_handler
 from fbpcp.decorator.metrics import request_counter, duration_time, error_counter
 from fbpcp.entity.cluster_instance import Cluster
+from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.gateway.aws import AWSGateway
 from fbpcp.mapper.aws import (
     map_ecstask_to_containerinstance,
     map_esccluster_to_clusterinstance,
+    map_ecstaskdefinition_to_containerdefinition,
 )
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.metrics.getter import MetricsGetter
@@ -133,3 +135,12 @@ class ECSGateway(AWSGateway, MetricsGetter):
     @error_handler
     def list_clusters(self) -> List[str]:
         return self.client.list_clusters()["clusterArns"]
+
+    @error_handler
+    def describe_task_definition(self, task_defination: str) -> ContainerDefinition:
+        response = self.client.describe_task_definition(
+            taskDefinition=task_defination, include=["TAGS"]
+        )
+        return map_ecstaskdefinition_to_containerdefinition(
+            response["taskDefinition"], response["tags"]
+        )

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List
 
 from fbpcp.entity.cloud_cost import CloudCost, CloudCostItem
 from fbpcp.entity.cluster_instance import Cluster, ClusterStatus
+from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.entity.firewall_ruleset import FirewallRule, FirewallRuleset
 from fbpcp.entity.route_table import (
@@ -194,3 +195,30 @@ def map_ec2vpcpeering_to_vpcpeering(
         else {}
     )
     return VpcPeering(id, status, role, requester_vpc_id, accepter_vpc_id, tags)
+
+
+def map_ecstaskdefinition_to_containerdefinition(
+    task_definition: Dict[str, Any],
+    tag_list: List[Dict[str, str]],
+) -> ContainerDefinition:
+    task_definition_id = task_definition["taskDefinitionArn"]
+    container_definition = task_definition["containerDefinitions"][0]
+    image = container_definition["image"]
+    cpu = container_definition["cpu"]
+    memory = container_definition["memory"]
+    entry_point = container_definition["entryPoint"]
+    environment = convert_list_to_dict(
+        container_definition["environment"], "name", "value"
+    )
+    task_role_id = task_definition["taskRoleArn"]
+    tags = convert_list_to_dict(tag_list, "key", "value")
+    return ContainerDefinition(
+        task_definition_id,
+        image,
+        cpu,
+        memory,
+        entry_point,
+        environment,
+        task_role_id,
+        tags,
+    )

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -22,6 +22,7 @@ from fbpcp.entity.route_table import (
 )
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc, VpcState
+from fbpcp.entity.vpc_peering import VpcPeering, VpcPeeringRole, VpcPeeringState
 from fbpcp.util.aws import convert_list_to_dict
 
 
@@ -171,3 +172,25 @@ def map_ec2securitygroup_to_firewallruleset(
         for ip_permission in security_group["IpPermissionsEgress"]
     ]
     return FirewallRuleset(id, vpc_id, ingress, egress, tags)
+
+
+def map_ec2vpcpeering_to_vpcpeering(
+    vpc_peering: Dict[str, Any], vpc_id: str
+) -> VpcPeering:
+    id = vpc_peering["VpcPeeringConnectionId"]
+    status = VpcPeeringState.PENDING_ACCEPTANCE
+    if vpc_peering["Status"]["Code"] == "active":
+        status = VpcPeeringState.ACTIVE
+    requester_vpc_id = vpc_peering["RequesterVpcInfo"]["VpcId"]
+    accepter_vpc_id = vpc_peering["AccepterVpcInfo"]["VpcId"]
+    role = (
+        VpcPeeringRole.REQUESTER
+        if requester_vpc_id == vpc_id
+        else VpcPeeringRole.ACCEPTER
+    )
+    tags = (
+        convert_list_to_dict(vpc_peering["Tags"], "Key", "Value")
+        if "Tags" in vpc_peering
+        else {}
+    )
+    return VpcPeering(id, status, role, requester_vpc_id, accepter_vpc_id, tags)

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -8,13 +8,16 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.cluster_instance import ClusterStatus, Cluster
+from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.gateway.ecs import ECSGateway
+from fbpcp.util.aws import convert_list_to_dict
 
 
 class TestECSGateway(unittest.TestCase):
     TEST_TASK_ARN = "test-task-arn"
     TEST_TASK_DEFINITION = "test-task-definition"
+    TEST_TASK_DEFINITION_ARN = "test-task-definition-arn"
     TEST_CONTAINER = "test-container"
     TEST_CLUSTER = "test-cluster"
     TEST_CMD = "test-cmd"
@@ -175,3 +178,47 @@ class TestECSGateway(unittest.TestCase):
         ]
         self.assertEqual(expected_clusters, clusters)
         self.gw.client.describe_clusters.assert_called()
+
+    def test_describe_task_definition(self):
+        task_definition_name = "onedocker-task_pce_id"
+        test_image = "test_image"
+        test_cpu = 4096
+        test_memory = 30720
+        test_entry_point = ["sh", "-c"]
+        test_environment = [{"name": "USER", "value": "ubuntu"}]
+        test_task_role = "test-task-role"
+        test_tags = [{"key": "pce-id", "value": "zehuali_test"}]
+        client_return_response = {
+            "taskDefinition": {
+                "taskDefinitionArn": self.TEST_TASK_DEFINITION_ARN,
+                "containerDefinitions": [
+                    {
+                        "image": test_image,
+                        "cpu": test_cpu,
+                        "memory": test_memory,
+                        "entryPoint": test_entry_point,
+                        "environment": test_environment,
+                    }
+                ],
+                "taskRoleArn": test_task_role,
+            },
+            "tags": test_tags,
+        }
+        self.gw.client.describe_task_definition = MagicMock(
+            return_value=client_return_response
+        )
+        test_tags_dict = convert_list_to_dict(test_tags, "key", "value")
+        test_environment_dict = convert_list_to_dict(test_environment, "name", "value")
+        container_definition = self.gw.describe_task_definition(task_definition_name)
+        expected_container_definition = ContainerDefinition(
+            self.TEST_TASK_DEFINITION_ARN,
+            test_image,
+            test_cpu,
+            test_memory,
+            test_entry_point,
+            test_environment_dict,
+            test_task_role,
+            test_tags_dict,
+        )
+        self.assertEqual(expected_container_definition, container_definition)
+        self.gw.client.describe_task_definition.assert_called()


### PR DESCRIPTION
Summary:
**What:**
2. Add gateway to describe the task definition from aws.
3. Add mapper function to map the aws response to pce entity.
4. Add integration test and unit test.

**RFC:**
We have a circular dependency issue if the entity don't live in the same package with the aws gateway and mapper classes. I want to get some advise here. Which is better? Move the `container_definition.py` to oss or we move all gateway and mapper related to the `container_definition` out of oss?

Differential Revision: D30812929

