### PR TITLE
Add BillingMonitorService and AWSBillingMonitorService

### DIFF
--- a/fbpcp/service/billing_monitor.py
+++ b/fbpcp/service/billing_monitor.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import abc
+
+from fbpcp.entity.cloud_cost import CloudCost
+
+
+class BillingMonitorService(abc.ABC):
+    @abc.abstractmethod
+    def emit_costs_metrics(self, cloud_cost: CloudCost) -> None:
+        pass

--- a/fbpcp/service/billing_monitor_aws.py
+++ b/fbpcp/service/billing_monitor_aws.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from datetime import date
+
+from fbpcp.entity.cloud_cost import CloudCost, CloudCostItem
+from fbpcp.metrics.emitter import MetricsEmitter
+from fbpcp.service.billing_monitor import BillingMonitorService
+
+METRICS_BILLING_GAUGE = "onedocker.container.count"
+
+
+class AWSBillingMonitorService(BillingMonitorService):
+    def __init__(self, metrics: MetricsEmitter) -> None:
+        self.metrics = metrics
+
+    def emit_costs_metrics(
+        self,
+        cost_date: date,
+        cloud_cost: CloudCost,
+    ) -> None:
+        pass
+
+    def _emit_metric(self, clould_cost_item: CloudCostItem) -> None:
+        pass


### PR DESCRIPTION
Summary: Add BillingMonitorService interface and AWS implementation AWSBillingMonitorService. This service receives the CloudCost as input, emit the total and desired service/region individual CloudCostItem via MetricsEmitter

Differential Revision: D30819800

