### PR TITLE
Add wait_for_running_containers util function and apply it to onedocker cli

### DIFF
--- a/onedocker/script/cli/onedocker_cli.py
+++ b/onedocker/script/cli/onedocker_cli.py
@@ -21,6 +21,7 @@ Options:
     --verbose                Set logging level to DEBUG
 """
 
+import asyncio
 import logging
 import os
 import time
@@ -77,6 +78,9 @@ def _test(
         version=version,
         cmd_args=cmd_args,
         timeout=DEFAULT_TIMEOUT,
+    )
+    container = asyncio.run(
+        onedocker_svc.wait_for_pending_container(container.instance_id)
     )
     logger.info(container)
     log_path = log_svc.get_log_path(container)

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
@@ -167,7 +167,7 @@ class TestMPCService(unittest.TestCase):
                 ContainerInstanceStatus.STARTED,
             )
         ]
-        self.mpc_service.container_svc.create_instances = MagicMock(
+        self.mpc_service.onedocker_svc.start_containers_async = AsyncMock(
             return_value=created_instances
         )
         built_onedocker_args = ("private_lift/lift", "test one docker arguments")


### PR DESCRIPTION
Summary:
## Context
mpc aem perf test wants to migrate to OSS version of OneDocker CLI and OneDocker CLI is one of the users for OneDocker Service. I extracted the logic of waiting for running containers into an util function so upstream callers can wait for running containers if needed.

## Summary
1. Added the util function to wait for running containers
2. Wait for container in OneDocker CLI

## Next
1. In the long term, we want to remove start_containers_async in onedocker service, this is the first step towards that.
2. Deprecate old onedocker cli

Differential Revision: D30976285

