### PR TITLE
Deprecate list_tasks

### DIFF
--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -84,9 +84,6 @@ class AWSContainerService(ContainerService):
     def get_instances(self, instance_ids: List[str]) -> List[ContainerInstance]:
         return self.ecs_gateway.describe_tasks(self.cluster, instance_ids)
 
-    def list_tasks(self) -> List[str]:
-        return self.ecs_gateway.list_tasks(cluster=self.cluster)
-
     def cancel_instance(self, instance_id: str) -> None:
         return self.ecs_gateway.stop_task(cluster=self.cluster, task_id=instance_id)
 

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -105,11 +105,6 @@ class TestAWSContainerService(unittest.TestCase):
         )
         self.assertEqual(instances, container_instances)
 
-    def test_list_tasks(self):
-        instance_ids = [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
-        self.container_svc.ecs_gateway.list_tasks = MagicMock(return_value=instance_ids)
-        self.assertEqual(instance_ids, self.container_svc.list_tasks())
-
     def test_cancel_instances(self):
         instance_ids = [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
         errors = [None, PcpError("instance id not found")]


### PR DESCRIPTION
Summary:
list_tasks is not defined in ContainerService. We shouldn't add custom methods. It will ruin the defined interface. Looks like it's introduced in D25739819.

As everyone has onboarded to OneDocker and we provide timeout from OneDocker, we don't have to manually kill the containers.

Also given the conversation we had recently, this aws-cli tool is rarely used now.

Differential Revision: D31042674

