### PR TITLE
Remove region from BillingService and CostExplorerGateway

### DIFF
--- a/fbpcp/gateway/aws.py
+++ b/fbpcp/gateway/aws.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 class AWSGateway:
     def __init__(
         self,
-        region: str,
+        region: Optional[str] = None,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,

--- a/fbpcp/gateway/costexplorer.py
+++ b/fbpcp/gateway/costexplorer.py
@@ -20,14 +20,15 @@ COST_GRANULARITY = "DAILY"
 class CostExplorerGateway(AWSGateway):
     def __init__(
         self,
-        region: str,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
     ) -> None:
-        super().__init__(region, access_key_id, access_key_data, config)
+        super().__init__(
+            access_key_id=access_key_id, access_key_data=access_key_data, config=config
+        )
         # pyre-ignore
-        self.client = boto3.client("ce", region_name=self.region, **self.config)
+        self.client = boto3.client("ce", **self.config)
 
     @error_handler
     def get_cost(self, start_date: str, end_date: str) -> CloudCost:

--- a/fbpcp/service/billing_aws.py
+++ b/fbpcp/service/billing_aws.py
@@ -17,14 +17,11 @@ from fbpcp.service.billing import BillingService
 class AWSBillingService(BillingService):
     def __init__(
         self,
-        region: str,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self.ce_gateway = CostExplorerGateway(
-            region, access_key_id, access_key_data, config
-        )
+        self.ce_gateway = CostExplorerGateway(access_key_id, access_key_data, config)
 
     def get_cost(self, start_date: date, end_date: date) -> CloudCost:
         """Get cost between start_date and end_date

--- a/tests/gateway/test_clouexplorer.py
+++ b/tests/gateway/test_clouexplorer.py
@@ -15,14 +15,13 @@ from fbpcp.gateway.costexplorer import CostExplorerGateway
 
 
 class TestCostExplorerGateway(unittest.TestCase):
-    REGION = "us-west-2"
     TEST_ACCESS_KEY_ID = "test-access-key-id"
     TEST_ACCESS_KEY_DATA = "test-access-key-data"
 
     @patch("boto3.client")
     def setUp(self, BotoClient):
         self.gw = CostExplorerGateway(
-            self.REGION, self.TEST_ACCESS_KEY_ID, self.TEST_ACCESS_KEY_DATA
+            self.TEST_ACCESS_KEY_ID, self.TEST_ACCESS_KEY_DATA
         )
         self.gw.client = BotoClient()
 


### PR DESCRIPTION
Summary:
**What**
- remove region from the input variable from BillingService and CostExplorerGateway
- make region optional in AWSGateway

**Why**
For billing service and CostExplorerGateway, region is not used. Boto client for costExplorer doesn't need region as input. It will always return all regions unless desire regions are listed in filter. So having this region in the constructor might confuse user. Also make this region optional in AWSGateway because there are some other boto clients doesn't need this region (e.g. S3) and we will want to clean it up as well.

Differential Revision: D31059590

