### PR TITLE
Remove storage_svc from MPCService's constructor

### DIFF
--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -16,7 +16,6 @@ from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
 from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
-from fbpcp.service.storage import StorageService
 from fbpcp.util.typing import checked_cast
 
 DEFAULT_BINARY_VERSION = "latest"
@@ -30,7 +29,6 @@ class MPCService:
     def __init__(
         self,
         container_svc: ContainerService,
-        storage_svc: StorageService,
         instance_repository: MPCInstanceRepository,
         task_definition: str,
         mpc_game_svc: MPCGameService,
@@ -38,24 +36,17 @@ class MPCService:
         """Constructor of MPCService
         Keyword arguments:
         container_svc -- service to spawn container instances
-        storage_svc -- service to read/write input/output files
         instance_repository -- repository to CRUD MPCInstance
         task_definition -- containers task definition
         mpc_game_svc -- service to generate package name and game arguments.
         """
-        if (
-            container_svc is None
-            or storage_svc is None
-            or instance_repository is None
-            or mpc_game_svc is None
-        ):
+        if container_svc is None or instance_repository is None or mpc_game_svc is None:
             raise ValueError(
                 f"Dependency is missing. container_svc={container_svc}, mpc_game_svc={mpc_game_svc}, "
-                f"storage_svc={storage_svc}, instance_repository={instance_repository}"
+                f"instance_repository={instance_repository}"
             )
 
         self.container_svc = container_svc
-        self.storage_svc = storage_svc
         self.instance_repository = instance_repository
         self.task_definition = task_definition
         self.mpc_game_svc: MPCGameService = mpc_game_svc

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -39,18 +39,15 @@ GAME_ARGS = [
 class TestMPCService(unittest.TestCase):
     def setUp(self):
         cspatcher = patch("fbpcp.service.container.ContainerService")
-        sspatcher = patch("fbpcp.service.storage.StorageService")
         irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
         gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
         container_svc = cspatcher.start()
-        storage_svc = sspatcher.start()
         instance_repository = irpatcher.start()
         mpc_game_svc = gspatcher.start()
-        for patcher in (cspatcher, sspatcher, irpatcher, gspatcher):
+        for patcher in (cspatcher, irpatcher, gspatcher):
             self.addCleanup(patcher.stop)
         self.mpc_service = MPCService(
             container_svc,
-            storage_svc,
             instance_repository,
             "test_task_definition",
             mpc_game_svc,


### PR DESCRIPTION
Summary: I just noticed that MPCService requires storage service. It doesn't seem right. I think it's introduced because we needed it for ip exchange. This feature has been deprecated long time ago. Unfortunately, PL depends on it in a wrong way. PL should depend on MPCService, shouldn't depend on a dependency of MPCService, so we need to fix them.

Differential Revision: D31226903

