### PR TITLE
Onedocker ignoring binary version

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -141,6 +141,7 @@ class OneDockerService(MetricsGetter):
         containers = self.start_containers(
             package_name=package_name,
             task_definition=task_definition,
+            version=version,
             cmd_args_list=cmd_args_list,
             env_vars=env_vars,
             timeout=timeout,


### PR DESCRIPTION
Summary:
The solutions pod is fighting for a Sev 3 S246342. The E2E test script told us that the PL rc binaries worked fine, so we promoted them to prod this afternoon, but turned out that the shard aggregator binary crashed. As we investigated why the E2E test didn't catch that, we noticed that this version parameter is ignored.

This diff won't resolve the sev but it's necessary to prevent it from happening again.

Differential Revision: D31424129

