### PR TITLE
update `map_aws_error` to include the full error message in the thrown exceptions

### DIFF
--- a/fbpcp/decorator/error_handler.py
+++ b/fbpcp/decorator/error_handler.py
@@ -16,10 +16,10 @@ def error_handler(f: Callable) -> Callable:
         try:
             return f(*args, **kwargs)
         except PcpError as err:
-            raise err
+            raise err from None
         except ClientError as err:
-            raise map_aws_error(err)
+            raise map_aws_error(err) from None
         except Exception as err:
-            raise PcpError(err)
+            raise PcpError(err) from None
 
     return wrap

--- a/fbpcp/error/mapper/aws.py
+++ b/fbpcp/error/mapper/aws.py
@@ -15,7 +15,7 @@ from fbpcp.error.pcp import ThrottlingError
 # reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
 def map_aws_error(error: ClientError) -> PcpError:
     code = error.response["Error"]["Code"]
-    message = error.response["Error"]["Message"]
+    message = str(error)
 
     if code == "InvalidParameterException":
         return InvalidParameterError(message)


### PR DESCRIPTION
Summary: We should include a more detailed error message so it can be more useful for troubleshooting.

Differential Revision: D31810770

