### PR TITLE
Suppressing raw exception messages in error_handler.

### DIFF
--- a/fbpcp/decorator/error_handler.py
+++ b/fbpcp/decorator/error_handler.py
@@ -16,10 +16,10 @@ def error_handler(f: Callable) -> Callable:
         try:
             return f(*args, **kwargs)
         except PcpError as err:
-            raise err
+            raise err from None
         except ClientError as err:
-            raise map_aws_error(err)
+            raise map_aws_error(err) from None
         except Exception as err:
-            raise PcpError(err)
+            raise PcpError(err) from None
 
     return wrap


### PR DESCRIPTION
Summary:
`error_handler` is responsible for mapping cloud provider specific exceptions to one of the modeled PCP exceptions.

Currently, `error_handler` does not suppress exception context, causing both the raw exception and the PCP exception to appear in the log.

This behavior is a leak of abstraction. At the same time, the message (**"During handling of the above exception, another exception occurred"**) can cause confusions.

Reference: https://www.python.org/dev/peps/pep-0409/

Differential Revision: D31810231

