### PR TITLE
Release: fbpcp 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,10 @@ Add support for single-word OneDocker package in OneDocker Runner
 
 ### Description of changes
 Bug fix in onedocker service to add missing binary version when start containers
+
+## 0.1.6 -> 0.2.0
+### Types of changes
+*  New feature (non-breaking change which adds functionality)
+
+### Description of changes
+Release PCE validator and update onedocker dependencies

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.1.6",
+    version="0.2.0",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
Release fbpcp 0.2.0, including
 - PCE validator in
 - Update onedocker dependencies

Differential Revision: D31846474

