### PR TITLE
Define the behavior of `get_instance` and `get_instances` for container service.

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -46,10 +46,29 @@ class ContainerService(abc.ABC):
 
     @abc.abstractmethod
     def get_instance(self, instance_id: str) -> ContainerInstance:
+        """Get a specific container instance.
+
+        Args:
+            instance_id: uniquely identify a container instance.
+
+        Returns:
+            A container instance.
+
+        Raises:
+            PcpError: The specified container instance wasn't found in the cluster.
+        """
         pass
 
     @abc.abstractmethod
     def get_instances(self, instance_ids: List[str]) -> List[ContainerInstance]:
+        """Get one or more container instances.
+
+        Args:
+            instance_ids: the instance ids of the container instances.
+
+        Returns:
+            A list of found container instances.
+        """
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
Summary:
This diff has two purposes:

1. To explicitly document how the current APIs handle non-existent resources; in order to resolve the ambiguity arised during GCP implementations. For now, there is no code change needed for ECS Container Service.

2. To request for comments for the following API proposal; in order to handle non-existent resource better. (The proposal is based on some offline discussions, but want more inputs and make sure everyone aligns).

```
    # return found instance or None
    def get_instance(self, instance_id: str) -> Optional[ContainerInstance]:

    # return a list of Optional, in the same order as the input ids. For example, if users pass 3 instance_ids and the second instance could not be found, then returned list should also have 3 elements, with the 2nd elements being None.
    def get_instances(self, instance_ids: List[str]) -> List[Optional[ContainerInstance]]:
```

Next step: to decide if we should update the API bahavior. If yes, I can file a separate task (can be a ramp up/Bootcamp task).

Reviewed By: peking2

Differential Revision: D31849247

