### PR TITLE
Add the container name for the task definition

### DIFF
--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -24,7 +24,7 @@ from fbpcp.entity.route_table import (
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc, VpcState
 from fbpcp.entity.vpc_peering import VpcPeering, VpcPeeringRole, VpcPeeringState
-from fbpcp.util.aws import convert_list_to_dict
+from fbpcp.util.aws import convert_list_to_dict, get_container_definition_id
 
 
 def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
@@ -195,8 +195,12 @@ def map_ecstaskdefinition_to_containerdefinition(
     task_definition: Dict[str, Any],
     tag_list: List[Dict[str, str]],
 ) -> ContainerDefinition:
-    task_definition_id = task_definition["taskDefinitionArn"]
+    task_definition_arn = task_definition["taskDefinitionArn"]
     container_definition = task_definition["containerDefinitions"][0]
+    container_name = container_definition["name"]
+    task_definition_id = get_container_definition_id(
+        task_definition_arn, container_name
+    )
     image = container_definition["image"]
     cpu = container_definition.get("cpu", task_definition.get("cpu"))
     memory = container_definition.get("memory", task_definition.get("memory"))

--- a/fbpcp/util/aws.py
+++ b/fbpcp/util/aws.py
@@ -76,3 +76,8 @@ def convert_vpc_tags_to_filter(
     tags_dict = prepare_tags(tags) if tags else {}
     filter_dict = {**vpc_dict, **tags_dict}
     return convert_dict_to_list(filter_dict, "Name", "Values") if filter_dict else []
+
+
+def get_container_definition_id(task_definition_id: str, container: str) -> str:
+    # the reverse logic from https://fburl.com/code/ycdjih3q
+    return f"{task_definition_id}#{container}"

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -11,7 +11,7 @@ from fbpcp.entity.cluster_instance import ClusterStatus, Cluster
 from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.gateway.ecs import ECSGateway
-from fbpcp.util.aws import convert_list_to_dict
+from fbpcp.util.aws import convert_list_to_dict, get_container_definition_id
 
 
 class TestECSGateway(unittest.TestCase):
@@ -227,11 +227,16 @@ class TestECSGateway(unittest.TestCase):
         test_environment = [{"name": "USER", "value": "ubuntu"}]
         test_task_role = "test-task-role"
         test_tags = [{"key": "pce-id", "value": "zehuali_test"}]
+        test_container_name = "container_name"
+        test_container_definition_id = get_container_definition_id(
+            self.TEST_TASK_DEFINITION_ARN, test_container_name
+        )
         client_return_response = {
             "taskDefinition": {
                 "taskDefinitionArn": self.TEST_TASK_DEFINITION_ARN,
                 "containerDefinitions": [
                     {
+                        "name": test_container_name,
                         "image": test_image,
                         "cpu": test_cpu,
                         "memory": test_memory,
@@ -254,7 +259,7 @@ class TestECSGateway(unittest.TestCase):
         container_definition = self.gw.describe_task_definition(task_definition_name)
         container_definitions = self.gw.describe_task_definitions(tags=test_tags_dict)
         expected_container_definition = ContainerDefinition(
-            self.TEST_TASK_DEFINITION_ARN,
+            test_container_definition_id,
             test_image,
             test_cpu,
             test_memory,


### PR DESCRIPTION
Summary:
Add the container_definition that used by onedocker as a name field in PCE container definition entity.
Why: we need this information in order to let onedocker service to run tasks.

Open questions:
1. Do we still want the `id` field of the container definition entity, seems no one will use it?
2. Do we want to put the logic to create the `container_definition` by `task_definition` and `container_name` in the pce service library level?

Reviewed By: ajaybhargavb

Differential Revision: D31877213

