### PR TITLE
fbpcp release automation: change github trigger event [2/n]

### DIFF
--- a/.github/workflows/publish_project.yml
+++ b/.github/workflows/publish_project.yml
@@ -1,12 +1,40 @@
 name: Build and Publish Python Distributions to PyPI
 
 on:
-  release:
-      types: [created]
+  push:
+    branches: [ main ]
+    paths:
+      - 'setup.py'
 jobs:
+  check-package-version:
+    name: Check Package Version
+    runs-on: ubuntu-18.04
+    outputs:
+      version_check: ${{ steps.version_check.outputs.version_check }}
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install packages
+      run: >-
+        python3 -m
+        pip install
+        requests packaging
+    - name: Package version check
+      run: >-
+       python3 ./scripts/compare_package_version.py
+    - name: Get version check output
+      id: version_check
+      run: >-
+       echo "::set-output name=version_check::$(python3 ./scripts/compare_package_version.py | tail -1)"
+
   build-n-publish:
     name: Build and publish distributions to PyPI
     runs-on: ubuntu-18.04
+    needs: check-package-version
+    if : needs.check-package-version.outputs.version_check == 'higher'
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.8


### PR DESCRIPTION
Summary:
Update github workflow trigger event to be a change to "setup.py" file

Whenever there is a change to setup.py, this workflow will get triggered.
Jobs:
1.Check Package Version: to check if setup.py version higher than remote Pypi version
2.Build and publish distributions to PyPI: Only when previous job is true, it will continue release

Differential Revision: D31898959

