### PR TITLE
Update container service API and the API consumers

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -60,14 +60,18 @@ class ContainerService(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_instances(self, instance_ids: List[str]) -> List[ContainerInstance]:
+    def get_instances(
+        self, instance_ids: List[str]
+    ) -> List[Optional[ContainerInstance]]:
         """Get one or more container instances.
 
         Args:
             instance_ids: the instance ids of the container instances.
 
         Returns:
-            A list of found container instances.
+            A list of Optional, in the same order as the input ids. For example, if
+            users pass 3 instance_ids and the second instance could not be found,
+            then returned list should also have 3 elements, with the 2nd elements being None.
         """
         pass
 

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -81,7 +81,9 @@ class AWSContainerService(ContainerService):
     def get_instance(self, instance_id: str) -> ContainerInstance:
         return self.ecs_gateway.describe_task(self.cluster, instance_id)
 
-    def get_instances(self, instance_ids: List[str]) -> List[ContainerInstance]:
+    def get_instances(
+        self, instance_ids: List[str]
+    ) -> List[Optional[ContainerInstance]]:
         return self.ecs_gateway.describe_tasks(self.cluster, instance_ids)
 
     def cancel_instance(self, instance_id: str) -> None:

--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -273,7 +273,7 @@ class MPCService:
         self, containers: List[ContainerInstance]
     ) -> List[ContainerInstance]:
         ids = [container.instance_id for container in containers]
-        return self.container_svc.get_instances(ids)
+        return list(filter(None, self.container_svc.get_instances(ids)))
 
     def _get_instance_status(self, instance: MPCInstance) -> MPCInstanceStatus:
         if instance.status is MPCInstanceStatus.CANCELED:

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -164,17 +164,26 @@ class OneDockerService(MetricsGetter):
         res = await asyncio.gather(*tasks)
         return [checked_cast(ContainerInstance, container) for container in res]
 
-    async def wait_for_pending_container(self, container_id: str) -> ContainerInstance:
+    async def wait_for_pending_container(
+        self, container_id: str
+    ) -> Optional[ContainerInstance]:
         updated_container = self.get_containers([container_id])[0]
-        while updated_container.status is ContainerInstanceStatus.UNKNOWN:
+        while (
+            updated_container is None
+            or updated_container.status is ContainerInstanceStatus.UNKNOWN
+        ):
             await asyncio.sleep(1)
             updated_container = self.get_containers([container_id])[0]
+            if updated_container is None:
+                break
         return updated_container
 
     def stop_containers(self, containers: List[str]) -> List[Optional[PcpError]]:
         return self.container_svc.cancel_instances(containers)
 
-    def get_containers(self, instance_ids: List[str]) -> List[ContainerInstance]:
+    def get_containers(
+        self, instance_ids: List[str]
+    ) -> List[Optional[ContainerInstance]]:
         return self.container_svc.get_instances(instance_ids)
 
     def _get_exe_name(self, package_name: str) -> str:


### PR DESCRIPTION
Summary:
Update the abstract base method `get_instances(ids)` to return `List[Optional[ContainerInstances]]`
and all downstream consumer code to update to the new API,
while keeping all previous functionalities as of now (e.g. filter out possible `None`s to match old type)

Differential Revision: D31910817

