### PR TITLE
Enforce pyre strict on test_util file

### DIFF
--- a/onedocker/tests/common/test_util.py
+++ b/onedocker/tests/common/test_util.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import subprocess
 import unittest
 
@@ -11,8 +13,8 @@ from onedocker.common.util import run_cmd
 
 
 class TestUtil(unittest.TestCase):
-    def test_run_cmd(self):
+    def test_run_cmd(self) -> None:
         self.assertEqual(0, run_cmd("cat", 1))
 
-    def test_run_cmd_with_timeout(self):
+    def test_run_cmd_with_timeout(self) -> None:
         self.assertRaises(subprocess.TimeoutExpired, run_cmd, "vi", 1)


### PR DESCRIPTION
Summary:
Added #pyre strict to force type annotation in fbcode/measurements/private_measurement/pcp/oss/onedocker/tests/common/test_util.py as per the following task

https://www.internalfb.com/tasks?p_nav=MY_TASKS&t=104022313

Differential Revision: D32101196

