### PR TITLE
Add more logging in describe_tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,11 @@ Bug fix in onedocker service to add missing binary version when start containers
 
 ### Description of changes
 Release PCE validator and update onedocker dependencies
+
+## 0.2.0 -> 0.2.1
+### Types of changes
+* New feature (non-breaking change which adds functionality)
+
+### Description of changes
+* API change: get_containers and get_instances now allows optional value
+* Add more logging in gateway level for better debugging

--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -95,7 +95,7 @@ class ECSGateway(AWSGateway, MetricsGetter):
         if not response["tasks"]:
             # common failures: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html
             failure = response["failures"][0]
-            self.logger.warn(f"ECSGateway failed to create a task. Failure: {failure}")
+            self.logger.error(f"ECSGateway failed to create a task. Failure: {failure}")
             raise PcpError(f"ECS failure: reason: {failure['reason']}")
 
         return map_ecstask_to_containerinstance(response["tasks"][0])
@@ -113,6 +113,11 @@ class ECSGateway(AWSGateway, MetricsGetter):
             arn_to_instance[
                 resp_task_dict["taskArn"]
             ] = map_ecstask_to_containerinstance(resp_task_dict)
+
+        for failure in response["failures"]:
+            self.logger.error(
+                f"ECSGateway failed to describe a task {failure['arn']}, reason: {failure['reason']}"
+            )
 
         return [arn_to_instance.get(arn, None) for arn in tasks]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.0",
+    version="0.2.1",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
PCS ran into some transient errors when calling get_containers in onedocker (It returns an empty list). Context: https://fburl.com/yj8upnw4

This diff is to add more logging in ecs gateway so that upstream callers can get ideas that what happended if there is any failure in the response.

Differential Revision: D32271713

