### PR TITLE
Create IAM gateway

### DIFF
--- a/pce/entity/iam_role.py
+++ b/pce/entity/iam_role.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+RoleId = str
+RoleName = str
+PolicyName = str
+PolicyContents = Dict[str, Any]
+
+
+@dataclass
+class IAMRole:
+    role_id: RoleId
+    attached_policy_contents: Dict[PolicyName, PolicyContents]

--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -3,13 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
+# pyre-strict
+
 from typing import List, Optional, Dict, Any
 
 import boto3
+from fbpcp.gateway.aws import AWSGateway
 
 
-class EC2Gateway:
+class EC2Gateway(AWSGateway):
     def __init__(
         self,
         region: str,
@@ -17,16 +19,9 @@ class EC2Gateway:
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self.logger: logging.Logger = logging.getLogger(__name__)
-        self.region = region
-        self.config: Dict[str, Any] = config or {}
+        super().__init__(region, access_key_id, access_key_data, config)
 
-        if access_key_id is not None:
-            self.config["aws_access_key_id"] = access_key_id
-
-        if access_key_data is not None:
-            self.config["aws_secret_access_key"] = access_key_data
-
+        # pyre-ignore
         self.client = boto3.client("ec2", region_name=self.region, **self.config)
 
     def describe_availability_zones(

--- a/pce/gateway/iam.py
+++ b/pce/gateway/iam.py
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from re import sub
+from typing import Optional, Dict, Any
+
+import boto3
+from fbpcp.gateway.aws import AWSGateway
+from pce.entity.iam_role import (
+    IAMRole,
+    RoleId,
+    RoleName,
+)
+from pce.mapper.aws import map_attachedrolepolicies_to_rolepolicies
+
+
+class IAMGateway(AWSGateway):
+    def __init__(
+        self,
+        region: str,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(region, access_key_id, access_key_data, config)
+
+        # pyre-ignore
+        self.client = boto3.client("iam", region_name=self.region, **self.config)
+
+    @classmethod
+    def _role_id_to_name(cls, role_id: RoleId) -> RoleName:
+        return sub(r".*?:role/", "", role_id)
+
+    def get_policies_for_role(
+        self,
+        role_id: RoleId,
+    ) -> Optional[IAMRole]:
+        return map_attachedrolepolicies_to_rolepolicies(
+            role_id,
+            {
+                policy["PolicyName"]:
+                # Retrieving the policy document requires retrieving the version id for each policy arn, hence `get_policy` has to be called for each `get_policy_version` invocation
+                self.client.get_policy_version(
+                    PolicyArn=policy["PolicyArn"],
+                    VersionId=self.client.get_policy(PolicyArn=policy["PolicyArn"])[
+                        "Policy"
+                    ]["DefaultVersionId"],
+                )["PolicyVersion"]["Document"]
+                for policy_result in self.client.get_paginator(
+                    "list_attached_role_policies"
+                ).paginate(RoleName=self._role_id_to_name(role_id))
+                for policy in policy_result["AttachedPolicies"]
+            },
+        )

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 from unittest import TestCase
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -14,13 +16,13 @@ REGION = "us-west-2"
 
 
 class TestEC2Gateway(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.aws_ec2 = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_ec2
             self.ec2 = EC2Gateway(REGION)
 
-    def test_describe_availability_zones(self):
+    def test_describe_availability_zones(self) -> None:
         client_return_response = {
             "AvailabilityZones": [
                 {

--- a/pce/gateway/tests/test_iam.py
+++ b/pce/gateway/tests/test_iam.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, call, MagicMock
+
+from pce.entity.iam_role import (
+    IAMRole,
+)
+from pce.gateway.iam import IAMGateway
+
+REGION = "us-west-2"
+
+
+class TestIAMGateway(TestCase):
+    def setUp(self) -> None:
+        self.aws_iam = MagicMock()
+        with patch("boto3.client") as mock_client:
+            mock_client.return_value = self.aws_iam
+            self.iam = IAMGateway(REGION)
+
+    def test_get_policies_for_role(self) -> None:
+        test_role_name_1 = "test_role_1"
+        test_role_name_2 = "test_role_2"
+        test_policy_name_1 = "test_policy_1"
+        test_policy_name_2 = "test_policy_2"
+
+        def role_name_to_arn(role_name: str) -> str:
+            return f"arn:aws:iam::123456789:role/{role_name}"
+
+        def policy_name_to_arn(policy_name: str) -> str:
+            return f"arn:aws:iam::aws:policy/service-role/{policy_name}"
+
+        test_policy_arn_1 = policy_name_to_arn(test_policy_name_1)
+        test_policy_arn_2 = policy_name_to_arn(test_policy_name_2)
+        test_role_arn_1 = role_name_to_arn(test_role_name_1)
+        test_role_arn_2 = role_name_to_arn(test_role_name_2)
+        test_policy_contents_1 = {"a1": "b1"}
+        test_policy_contents_2 = {"a2": "b2"}
+
+        mock_paginator = MagicMock()
+        mock_paginator.paginate = MagicMock(
+            side_effect=lambda RoleName: {
+                test_role_name_1: [
+                    {
+                        "AttachedPolicies": [
+                            {
+                                "PolicyName": test_policy_name_1,
+                                "PolicyArn": test_policy_arn_1,
+                            }
+                        ]
+                    }
+                ],
+                test_role_name_2: [
+                    {
+                        "AttachedPolicies": [
+                            {
+                                "PolicyName": test_policy_name_2,
+                                "PolicyArn": test_policy_arn_2,
+                            }
+                        ]
+                    }
+                ],
+            }[RoleName]
+        )
+
+        self.aws_iam.get_paginator = MagicMock(return_value=mock_paginator)
+
+        self.aws_iam.get_policy = MagicMock(
+            return_value={"Policy": {"DefaultVersionId": 1}}
+        )
+
+        self.aws_iam.get_policy_version = MagicMock(
+            side_effect=lambda PolicyArn, VersionId: {
+                test_policy_arn_1: {
+                    "PolicyVersion": {"Document": test_policy_contents_1}
+                },
+                test_policy_arn_2: {
+                    "PolicyVersion": {"Document": test_policy_contents_2}
+                },
+            }[PolicyArn]
+        )
+
+        test_expected_role_attached_policies = {
+            test_role_arn_1: IAMRole(
+                test_role_arn_1, {test_policy_name_1: test_policy_contents_1}
+            ),
+            test_role_arn_2: IAMRole(
+                test_role_arn_2, {test_policy_name_2: test_policy_contents_2}
+            ),
+        }
+
+        for (
+            role_id,
+            test_expected_role_attached_policy,
+        ) in test_expected_role_attached_policies.items():
+            policies = self.iam.get_policies_for_role(role_id)
+            self.assertEqual(
+                test_expected_role_attached_policy,
+                policies,
+            )
+
+        mock_paginator.paginate.assert_has_calls(
+            [
+                call(RoleName=IAMGateway._role_id_to_name(test_role_name))
+                for test_role_name in test_expected_role_attached_policies.keys()
+            ]
+        )
+
+    def test_role_id_to_name_slashes(self) -> None:
+        role_name = "application_abc/component_xyz/RDSAccess"
+        self.assertEqual(
+            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
+            role_name,
+        )
+
+    def test_role_id_to_name_no_slashes(self) -> None:
+        role_name = "RDSAccess"
+        self.assertEqual(
+            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
+            role_name,
+        )

--- a/pce/mapper/__init__.py
+++ b/pce/mapper/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pce/mapper/aws.py
+++ b/pce/mapper/aws.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Dict, Optional
+
+from pce.entity.iam_role import (
+    IAMRole,
+    RoleId,
+    PolicyName,
+    PolicyContents,
+)
+
+
+def map_attachedrolepolicies_to_rolepolicies(
+    role_id: RoleId,
+    attached_role_policies: Dict[PolicyName, PolicyContents],
+) -> Optional[IAMRole]:
+    return IAMRole(role_id, attached_role_policies) if attached_role_policies else None


### PR DESCRIPTION
Summary: Add a IAM gateway to retrieve policy documents attached to the roles the PCE container point to.

Differential Revision: D32144365

