### PR TITLE
Deprecate start_containers_async in onedocker

### DIFF
--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -262,12 +262,20 @@ class MPCService:
             )
         cmd_args_list = [cmd_args for (package_name, cmd_args) in cmd_tuple_list]
 
-        return await self.onedocker_svc.start_containers_async(
+        containers = self.onedocker_svc.start_containers(
             task_definition=self.task_definition,
             package_name=cmd_tuple_list[0][0],
             version=version,
             cmd_args_list=cmd_args_list,
             timeout=timeout,
+        )
+
+        self.logger.info(
+            f"Waiting for {len(containers)} container(s) to become started"
+        )
+
+        return await self.onedocker_svc.wait_for_pending_containers(
+            [container.instance_id for container in containers]
         )
 
     def _update_container_instances(

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -109,7 +109,7 @@ class OneDockerService(MetricsGetter):
             for cmd_args in cmd_args_list
         ]
 
-        self.logger.info("Spinning up container instances")
+        self.logger.info(f"Spinning up {len(cmds)} container instance[s]")
 
         task_definition = task_definition or self.task_definition
         if not task_definition:
@@ -127,32 +127,6 @@ class OneDockerService(MetricsGetter):
             name = f"{METRICS_CONTAINER_COUNT}.{tag}" if tag else name
             self.metrics.count(name, len(containers))
         return containers
-
-    async def start_containers_async(
-        self,
-        package_name: str,
-        task_definition: Optional[str] = None,
-        version: str = DEFAULT_BINARY_VERSION,
-        cmd_args_list: Optional[List[str]] = None,
-        env_vars: Optional[Dict[str, str]] = None,
-        timeout: Optional[int] = None,
-        tag: Optional[str] = None,
-    ) -> List[ContainerInstance]:
-        containers = self.start_containers(
-            package_name=package_name,
-            task_definition=task_definition,
-            version=version,
-            cmd_args_list=cmd_args_list,
-            env_vars=env_vars,
-            timeout=timeout,
-            tag=tag,
-        )
-        self.logger.info(
-            f"OneDockerService is waiting for {len(containers)} container(s) to become started"
-        )
-        return await self.wait_for_pending_containers(
-            [container.instance_id for container in containers]
-        )
 
     async def wait_for_pending_containers(
         self, container_ids: List[str]

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -164,7 +164,10 @@ class TestMPCService(unittest.TestCase):
                 ContainerInstanceStatus.STARTED,
             )
         ]
-        self.mpc_service.onedocker_svc.start_containers_async = AsyncMock(
+        self.mpc_service.onedocker_svc.start_containers = MagicMock(
+            return_value=created_instances
+        )
+        self.mpc_service.onedocker_svc.wait_for_pending_containers = AsyncMock(
             return_value=created_instances
         )
         built_onedocker_args = ("private_lift/lift", "test one docker arguments")


### PR DESCRIPTION
Summary: Upstrean solutions have already migrated to start_containers + wait_for_pending_containers. It's good timing for us to deprecate start_containers_async.

Differential Revision: D32484240

