### PR TITLE
apply inferred pyre types to pcp

### DIFF
--- a/onedocker/script/cli/onedocker_cli.py
+++ b/onedocker/script/cli/onedocker_cli.py
@@ -159,7 +159,7 @@ def _build_exe_s3_path(repository_path: str, package_name: str, version: str) ->
     return f"{repository_path}{package_name}/{version}/{package_name.split('/')[-1]}"
 
 
-def main():
+def main() -> None:
     global container_svc, onedocker_svc, onedocker_package_repo, log_svc, logger, task_definition, repository_path
     s = schema.Schema(
         {

--- a/pce/validator/validator.py
+++ b/pce/validator/validator.py
@@ -41,7 +41,7 @@ def validate_pce(region: str, key_id: str, key_data: str, pce_id: str) -> None:
         print("Your PCE environments are set up correctly.")
 
 
-def main():
+def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     s = Schema({"--region": str, "--key-id": str, "--key-data": str, "--pce-id": str})


### PR DESCRIPTION
Summary:
## What

* I autogenerated a ton of pyre typing for fbpcs and measurement/private_lift. Figured I'd do pcp too. If you don't want it, feel free to return it to my queue and I can abandon the diff.
 ---
* auto added pyre types with `pyre infer -i $(find . ! '(' -name 'test_*' -o -name '*_test.py' ')' | grep '.py')`
* I Ignore test files because adding typing messes up mocking. I'm not opening that can of worms

## Why

* To stop bootcampers from adding me to pyre diffs
    * think of my poor diff queue! The things it has seen!
    * jokes aside, there are a lot of easy pyre tasks out there that can't be automated. IMO, the optimal strategy is to automate what you can, let bootcampers handle easy pyre tasks that can't be automated, and make engineers with context handle the harder tasks.

Differential Revision: D32611785

