### PR TITLE
Update dependencies and release a new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,10 @@ Release PCE validator and update onedocker dependencies
 ### Description of changes
 * API change: get_containers and get_instances now allows optional value
 * Add more logging in gateway level for better debugging
+
+## 0.2.1 -> 0.2.2
+### Types of changes
+* Dependencies Updates
+
+### Description of changes
+* Update the version of dependencies to make them internally consistent and Fix the docker image vulnerables

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    "boto3==1.11.11",
+    "boto3==1.18.57",
+    "urllib3==1.26.7",
     "dataclasses-json==0.5.2",
     "pyyaml==5.4.1",
     "tqdm==4.55.1",
@@ -24,7 +25,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.1",
+    version="0.2.2",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
fbpcp exposes a vulnerable due to the low version of some dependencies.
So I update the version of dependencies to make them internally consistent and Fix the docker image vulnerables

The root cause of the vulnerable is urllib3, which is used by boto3 is too old.

More context: T105173350

> This diff will not ship until the red zone ends

Differential Revision: D32714430

