### PR TITLE
OSS GCS related modules so onedocker repository can use it

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ ignore =
   # Black conflicts and overlaps.
   # Found in https://github.com/psf/black/issues/429
   B950, # Line too long. (Use `arc lint`'s LINEWRAP instead)
+  C901, # The function is too complex
   E111, # Indentation is not a multiple of four.
   E115, # Expected an indented block (comment).
   E117, # Over-indented.

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -19,6 +19,9 @@
       "site-package": "pyyaml"
     },
     {
+      "site-package": "kubernetes"
+    },
+    {
       "site-package": "fbpcp"
     }
   ],

--- a/fbpcp/decorator/error_handler.py
+++ b/fbpcp/decorator/error_handler.py
@@ -8,7 +8,11 @@ from typing import Callable
 
 from botocore.exceptions import ClientError
 from fbpcp.error.mapper.aws import map_aws_error
+from fbpcp.error.mapper.gcp import map_gcp_error
+from fbpcp.error.mapper.k8s import map_k8s_error
 from fbpcp.error.pcp import PcpError
+from google.cloud.exceptions import GoogleCloudError
+from kubernetes.client.exceptions import OpenApiException
 
 
 def error_handler(f: Callable) -> Callable:
@@ -17,8 +21,14 @@ def error_handler(f: Callable) -> Callable:
             return f(*args, **kwargs)
         except PcpError as err:
             raise err from None
+        # AWS Error
         except ClientError as err:
             raise map_aws_error(err) from None
+        # GCP Error
+        except GoogleCloudError as err:
+            raise map_gcp_error(err) from None
+        except OpenApiException as err:
+            raise map_k8s_error(err) from None
         except Exception as err:
             raise PcpError(err) from None
 

--- a/fbpcp/error/mapper/gcp.py
+++ b/fbpcp/error/mapper/gcp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.error.pcp import InvalidParameterError
+from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import ThrottlingError
+from google.cloud.exceptions import GoogleCloudError
+
+
+# reference: https://gcloud.readthedocs.io/en/latest/_modules/google/cloud/exceptions.html
+def map_gcp_error(error: GoogleCloudError) -> PcpError:
+    code = error.code
+    message = error.message
+    if code == 429:
+        return ThrottlingError(message)
+    if code == 400:
+        return InvalidParameterError(message)
+    return PcpError(message)

--- a/fbpcp/error/mapper/k8s.py
+++ b/fbpcp/error/mapper/k8s.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.error.pcp import InvalidParameterError
+from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import ThrottlingError
+from kubernetes.client.exceptions import (
+    ApiException,
+    ApiValueError,
+    ApiTypeError,
+    OpenApiException,
+)
+
+# reference: https://github.com/kubernetes-client/python/blob/d3de7a85a63fa6bec6518d1cc75dc5e9458b9bbc/kubernetes/client/exceptions.py
+def map_k8s_error(error: OpenApiException) -> PcpError:
+    message = str(error)
+    if isinstance(error, (ApiValueError, ApiTypeError)):
+        return InvalidParameterError(message)
+    elif isinstance(error, ApiException):
+        code = error.status
+        if code == 429:
+            return ThrottlingError(message)
+        if code == 400 or code == 404:
+            return InvalidParameterError(message)
+
+    return PcpError(message)

--- a/fbpcp/gateway/gcp.py
+++ b/fbpcp/gateway/gcp.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+
+class GCPGateway:
+    def __init__(
+        self,
+        credentials_json: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.config: Dict[str, Any] = config or {}
+
+        if credentials_json is not None:
+            self.config["credentials_json"] = json.loads(credentials_json)

--- a/fbpcp/gateway/gcs.py
+++ b/fbpcp/gateway/gcs.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, List, Optional
+
+from fbpcp.decorator.error_handler import error_handler
+from fbpcp.gateway.gcp import GCPGateway
+from google.cloud import storage
+from google.oauth2.service_account import Credentials
+
+
+class GCSGateway(GCPGateway):
+    def __init__(
+        self,
+        credentials_json: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(credentials_json=credentials_json, config=config)
+        credentials = (
+            (Credentials.from_service_account_info(self.config["credentials_json"]))
+            if "credentials_json" in self.config.keys()
+            else None
+        )
+        project = credentials.project_id if credentials is not None else None
+
+        self.client = storage.Client(
+            project=project,
+            credentials=credentials,
+        )
+
+    @error_handler
+    def create_bucket(self, bucket: str, location: Optional[str] = None) -> None:
+        # If location is none, then the bucket will be created in US regions (multi-region)
+        self.client.create_bucket(bucket, location=location)
+
+    @error_handler
+    def delete_bucket(self, bucket: str) -> None:
+        bucket = self.client.get_bucket(bucket)
+        bucket.delete()
+
+    @error_handler
+    def upload_file(self, file_name: str, bucket: str, key: str) -> None:
+        # TODO: Add ProgressBar
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        blob.upload_from_filename(file_name)
+
+    @error_handler
+    def download_file(self, bucket: str, key: str, file_name: str) -> None:
+        # TODO: Add ProgressBar
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        blob.download_to_filename(file_name)
+
+    @error_handler
+    def put_object(self, bucket: str, key: str, data: str) -> None:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        blob.upload_from_string(data)
+
+    @error_handler
+    def get_object(self, bucket: str, key: str) -> str:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        return blob.download_as_string()
+
+    @error_handler
+    def get_object_size(self, bucket: str, key: str) -> int:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.get_blob(key)
+        return blob.size
+
+    @error_handler
+    def get_object_info(self, bucket: str, key: str) -> Dict[str, Any]:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.get_blob(key)
+        return {"size": blob.size, "updated": blob.updated}
+
+    @error_handler
+    def list_objects(self, bucket: str, key: str) -> List[str]:
+        """
+        Bucket:
+            fileA
+            fileB
+            different_prefix_file
+            folderA/fileC
+            folderB/fileD
+
+        list_blobs(bucker, prefix='file', delimiter='/') ->
+            fileA
+            fileB
+
+        list_blobs(bucker, prefix='folderA/', delimiter='/') ->
+            folderA/
+            folderA/fileC
+        """
+        blobs = self.client.list_blobs(bucket, prefix=key)
+        objects = []
+        for blob in blobs:
+            objects.append(blob.name)
+        return objects
+
+    @error_handler
+    def delete_object(self, bucket: str, key: str) -> None:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        blob.delete()
+
+    @error_handler
+    def object_exists(self, bucket: str, key: str) -> bool:
+        bucket = self.client.bucket(bucket)
+        blob = bucket.blob(key)
+        return blob.exists()
+
+    @error_handler
+    def copy(
+        self,
+        source_bucket_name: str,
+        source_key: str,
+        dest_bucket_name: str,
+        dest_key: str,
+    ) -> None:
+        source_bucket = self.client.bucket(source_bucket_name)
+        source_blob = source_bucket.blob(source_key)
+        dest_bucket = self.client.bucket(dest_bucket_name)
+
+        source_bucket.copy_blob(source_blob, dest_bucket, dest_key)

--- a/fbpcp/service/storage_gcs.py
+++ b/fbpcp/service/storage_gcs.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import glob
+import os
+from typing import Any, Dict, Optional, List
+
+from fbpcp.entity.file_information import FileInfo
+from fbpcp.gateway.gcs import GCSGateway
+from fbpcp.service.storage import StorageService, PathType
+from fbpcp.util.gcspath import GCSPath
+
+
+class GCSStorageService(StorageService):
+    def __init__(
+        self,
+        credentials_json: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.gcs_gateway = GCSGateway(credentials_json, config)
+
+    def __check_dir(self, local_dir: str) -> None:
+        if not os.path.exists(local_dir):
+            raise ValueError("directory does not exist: " + local_dir)
+
+    def read(self, filename: str) -> str:
+        """Read a file data
+
+        Args:
+            filename: fully qualified GCS filename (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+
+        Returns:
+            return: file contents as str
+        """
+        gcs_path = GCSPath(filename)
+        return self.gcs_gateway.get_object(gcs_path.bucket, gcs_path.key)
+
+    def write(self, filename: str, data: str) -> None:
+        """Write data into a file
+
+        Args:
+            filename: fully qualified GCS filename (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+            data: file contents as str
+        """
+        gcs_path = GCSPath(filename)
+        return self.gcs_gateway.put_object(gcs_path.bucket, gcs_path.key, data)
+
+    def copy(self, source: str, destination: str, recursive: bool = False) -> None:
+        """Move a file or folder between local storage and GCS, or between GCS and GCS
+
+        Args:
+            source: source file
+            destination: destination file
+            recursive: whether to recursively copy a folder
+
+        Raises:
+            ValueError: Source is folder and recursive is False
+            ValueError: Source is not a valid Local or GCS path
+            ValueError: Destination is not a valid Local or GCS path
+            ValueError: Both source and destination are the same
+            ValueError: Both source and destination are local
+        """
+        sourceType = StorageService.path_type(source)
+        destinationType = StorageService.path_type(destination)
+        if sourceType != PathType.GCS and sourceType != PathType.Local:
+            raise ValueError("Source is not a valid Local or GCS path")
+        if destinationType != PathType.GCS and destinationType != PathType.Local:
+            raise ValueError("Destination is not a valid Local or GCS path")
+        if source == destination:
+            raise ValueError("Both source and destination are the same")
+
+        # source is Local
+        if sourceType == PathType.Local:
+            if destinationType == PathType.Local:
+                raise ValueError("Both source and destination are local files")
+            else:
+                gcs_path = GCSPath(destination)
+                if recursive:
+                    self.upload_dir(
+                        source=source,
+                        gcs_path_bucket=gcs_path.bucket,
+                        gcs_path_key=gcs_path.key,
+                    )
+                else:
+                    if os.path.isdir(source):
+                        raise ValueError(
+                            f"Source {source} is a folder. Use --recursive"
+                        )
+                    self.gcs_gateway.upload_file(
+                        file_name=source, bucket=gcs_path.bucket, key=gcs_path.key
+                    )
+        # source is GCS
+        elif sourceType == PathType.GCS:
+            source_gcs_path = GCSPath(source)
+            if destinationType == PathType.Local:
+                if recursive:
+                    self.download_dir(
+                        gcs_path_bucket=source_gcs_path.bucket,
+                        gcs_path_key=source_gcs_path.key,
+                        destination=destination,
+                    )
+                else:
+                    self.gcs_gateway.download_file(
+                        bucket=source_gcs_path.bucket,
+                        key=source_gcs_path.key,
+                        filename=destination,
+                    )
+            elif destinationType == PathType.GCS:
+                destination_gcs_path = GCSPath(destination)
+                if recursive:
+                    self.copy_dir(
+                        source_bucket=source_gcs_path.bucket,
+                        source_key=source_gcs_path.key,
+                        destination_bucket=destination_gcs_path.bucket,
+                        destination_key=destination_gcs_path.key,
+                    )
+                else:
+                    self.gcs_gateway.copy(
+                        source_bucket_name=source_gcs_path.bucket,
+                        source_key=source_gcs_path.key,
+                        dest_bucket_name=destination_gcs_path.bucket,
+                        dest_key=destination_gcs_path.key,
+                    )
+
+    def upload_dir(self, source: str, gcs_path_bucket: str, gcs_path_key: str) -> None:
+        """Upload a directory from the filesystem to GCS
+
+        Args:
+            source: source directory (local)
+            gcs_path_bucket: GCS bucket
+            gcs_path_key: GCS key
+        """
+        # Check that source directory exists
+        self.__check_dir(source)
+
+        # Get list of files
+        rel_paths = glob.glob(source + "/**", recursive=True)
+        for local_file in rel_paths:
+            if os.path.isfile(local_file):
+                remote_path = local_file.replace(source, gcs_path_key, 1)
+                self.gcs_gateway.upload_file(
+                    file_name=local_file, bucket=gcs_path_bucket, key=remote_path
+                )
+
+    def download_dir(
+        self, gcs_path_bucket: str, gcs_path_key: str, destination: str
+    ) -> None:
+        """Recursively downloads a directory from GCS to the filesystem
+
+        Args:
+            gcs_path_bucket: GCS bucket
+            gcs_path_key: GCS key
+            destination: destination directory (local)
+        """
+        # Get list of files
+        blob_names = self.gcs_gateway.list_objects(
+            bucket=gcs_path_bucket, key=gcs_path_key
+        )
+        for blob_name in blob_names:
+            if blob_name.endswith("/"):
+                continue
+            file_split = destination.split("/") + blob_name.replace(
+                gcs_path_key, "", 1
+            ).split("/")
+            dir_name = "/".join(file_split[0:-1])
+            if not os.path.exists(dir_name):
+                os.makedirs(dir_name)
+            file_name = "/".join(file_split)
+            self.gcs_gateway.download_file(
+                bucket=gcs_path_bucket, key=blob_name, file_name=file_name
+            )
+
+    def copy_dir(
+        self,
+        source_bucket: str,
+        source_key: str,
+        destination_bucket: str,
+        destination_key: str,
+    ) -> None:
+        """Copy a directory from GCS to another directory in GCS
+
+        Args:
+            source_bucket: Source GCS bucket
+            source_key: Source GCS key (directory)
+            destination_bucket: Destination GCS bucket
+            destination_key: Destination GCS key (directory)
+
+        Raises:
+            ValueError: Source and Destination are the same
+        """
+        if source_bucket == destination_bucket and source_key == destination_key:
+            raise ValueError("Source and Destination are the same")
+
+        # Get list of files
+        src_blob_names = self.gcs_gateway.list_objects(
+            bucket=source_bucket, key=source_key
+        )
+        dest_key_split = destination_key.split("/")
+        for src_blob_name in src_blob_names:
+            if src_blob_name.endswith("/"):
+                continue
+            dest_file_name = "/".join(
+                dest_key_split + src_blob_name.replace(source_key, "", 1).split("/")
+            )
+            self.gcs_gateway.copy(
+                source_bucket, src_blob_name, destination_bucket, dest_file_name
+            )
+
+    def delete(self, filename: str) -> None:
+        """Delete a GCS file
+
+        Args:
+            filename: fully qualified GCS filename to be deleted (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+        """
+        gcs_path = GCSPath(filename)
+        return self.gcs_gateway.delete_object(gcs_path.bucket, gcs_path.key)
+
+    def file_exists(self, filename: str) -> bool:
+        """Check existence of a GCS file
+
+        Args:
+            filename: fully qualified GCS filename to be checked (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+        """
+        gcs_path = GCSPath(filename)
+        return self.gcs_gateway.object_exists(gcs_path.bucket, gcs_path.key)
+
+    def get_file_info(self, filename: str) -> FileInfo:
+        """Get file information
+
+        Args:
+            filename: fully qualified GCS filename to be inspected (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+
+        Returns:
+            FileInfo: file_name, file_size, last_modified
+        """
+        gcs_path = GCSPath(filename)
+        file_info = self.gcs_gateway.get_object_info(gcs_path.bucket, gcs_path.key)
+        return FileInfo(
+            file_name=filename,
+            last_modified=file_info.get("updated"),
+            file_size=file_info.get("size"),
+        )
+
+    def get_file_size(self, filename: str) -> int:
+        """Get file size
+
+        Args:
+            filename: fully qualified GCS filename to be inspected (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+
+        Returns:
+            int: file size (in bytes)
+        """
+        gcs_path = GCSPath(filename)
+        return self.gcs_gateway.get_object_size(gcs_path.bucket, gcs_path.key)
+
+    def list_folders(self, filename: str) -> List[str]:
+        """List folders
+
+        Args:
+            filename: fully qualified GCS filename to be inspected (ex: "https://storage.cloud.google.com/bucket-name/key-name")
+
+        Returns:
+            List[str]: List of folders found in filename
+        """
+        folders = []
+        gcs_path = GCSPath(filename)
+        blob_names = self.gcs_gateway.list_objects(
+            bucket=gcs_path.bucket, key=gcs_path.key
+        )
+        for blob_name in blob_names:
+            if blob_name.endswith("/"):
+                folders.append(blob_name)
+        return folders

--- a/fbpcp/util/gcspath.py
+++ b/fbpcp/util/gcspath.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import re
+from typing import Tuple
+
+
+class GCSPath:
+    bucket: str
+    key: str
+
+    def __init__(self, fileURL: str) -> None:
+        self.bucket, self.key = self._get_bucket_key(fileURL)
+
+    def __eq__(self, other: "GCSPath") -> bool:
+        return self.bucket == other.bucket and self.key == other.key
+
+    # virtual host style url
+    # https://storage.cloud.google.com/<bucket>/<key>
+    def _get_bucket_key(self, fileURL: str) -> Tuple[str, str]:
+        match = re.search("^https?://storage.cloud.google.com/(.*)$", fileURL)
+        if not match:
+            raise ValueError(f"Could not parse {fileURL} as an GCSPath")
+        bucket, *rest = match.group(1).split("/")
+        key = "/".join(rest)
+        return (bucket, key)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     "schema==0.7.0",
     "psutil==5.8.0",
     "click==7.1.2",
+    "kubernetes==12.0.1",
 ]
 
 with open("README.md", encoding="utf-8") as f:

--- a/tests/decorator/test_error_handler.py
+++ b/tests/decorator/test_error_handler.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from fbpcp.decorator.error_handler import error_handler
 from fbpcp.error.pcp import PcpError
 from fbpcp.error.pcp import ThrottlingError
+from google.cloud.exceptions import TooManyRequests
 
 
 class TestErrorHandler(unittest.TestCase):
@@ -54,3 +55,12 @@ class TestErrorHandler(unittest.TestCase):
             raise ValueError("just a test")
 
         self.assertRaises(PcpError, foo, "error1", "error2")
+
+    def test_gcp_throttling_error(self):
+        @error_handler
+        def foo():
+            # Exception mapping a 429 Too Many Requests response
+            err = TooManyRequests("test")
+            raise err
+
+        self.assertRaises(ThrottlingError, foo)

--- a/tests/error/mapper/test_gcp.py
+++ b/tests/error/mapper/test_gcp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from fbpcp.error.mapper.gcp import map_gcp_error
+from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import ThrottlingError
+from google.cloud.exceptions import GoogleCloudError
+
+
+class TestMapGCPError(unittest.TestCase):
+    def test_pcs_error(self) -> None:
+        err = GoogleCloudError("Test")
+        err = map_gcp_error(err)
+
+        self.assertIsInstance(err, PcpError)
+
+    def test_throttling_error(self) -> None:
+        err = GoogleCloudError("Test")
+        err.code = 429
+        err = map_gcp_error(err)
+
+        self.assertIsInstance(err, ThrottlingError)

--- a/tests/error/mapper/test_k8s.py
+++ b/tests/error/mapper/test_k8s.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from fbpcp.error.mapper.k8s import map_k8s_error
+from fbpcp.error.pcp import InvalidParameterError
+from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import ThrottlingError
+from kubernetes.client.exceptions import ApiException, ApiValueError, ApiTypeError
+
+
+class TestMapK8SError(unittest.TestCase):
+    def test_invalid_error(self):
+        src_errs = [
+            ApiValueError(
+                "Missing the required parameter `namespace` when calling `create_namespaced_job`"
+            ),
+            ApiTypeError(
+                "Got an unexpected keyword argument 'unexpected_arg' to method get_api_group"
+            ),
+            ApiException(status=400, reason="Bad Request"),
+        ]
+
+        for src_err in src_errs:
+            dst_err = map_k8s_error(src_err)
+            self.assertIsInstance(dst_err, InvalidParameterError)
+
+    def test_throttling_error(self):
+        src_err = ApiException(status=429, reason="Too Many Requests")
+        dst_err = map_k8s_error(src_err)
+
+        self.assertIsInstance(dst_err, ThrottlingError)
+
+    def test_default_pce_error(self):
+        src_err = ApiException(status=503, reason="Service Unavailable")
+        dst_err = map_k8s_error(src_err)
+
+        self.assertIsInstance(dst_err, PcpError)

--- a/tests/gateway/test_gcs.py
+++ b/tests/gateway/test_gcs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fbpcp.gateway.gcs import GCSGateway
+
+
+class TestGCSGateway(unittest.TestCase):
+    TEST_LOCAL_FILE = "test-local-file"
+    TEST_BUCKET = "test-bucket"
+    TEST_FILE = "test-file"
+    TEST_OBJECT_NAME = "test-object-name"
+    TEST_OBJECT_DATA = "test-object-data"
+
+    @patch("google.cloud.storage.Client")
+    def test_create_bucket(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.create_bucket = MagicMock(return_value=None)
+        gw.create_bucket(self.TEST_BUCKET)
+        gw.client.create_bucket.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_delete_bucket(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.get_bucket(self.TEST_BUCKET).delete = MagicMock(return_value=None)
+        gw.delete_bucket(self.TEST_BUCKET)
+        gw.client.get_bucket(self.TEST_BUCKET).delete.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_put_object(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).upload_from_string = MagicMock(return_value=None)
+        gw.put_object(self.TEST_BUCKET, self.TEST_OBJECT_NAME, self.TEST_OBJECT_DATA)
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).upload_from_string.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_upload_file(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).upload_from_filename = MagicMock(return_value=None)
+        gw.upload_file(self.TEST_BUCKET, self.TEST_LOCAL_FILE, self.TEST_FILE)
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).upload_from_filename.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_download_file(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).download_to_filename = MagicMock(return_value=None)
+        gw.download_file(self.TEST_BUCKET, self.TEST_FILE, self.TEST_LOCAL_FILE)
+        gw.client.bucket(self.TEST_BUCKET).blob(
+            self.TEST_OBJECT_NAME
+        ).download_to_filename.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_delete_object(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).blob(self.TEST_FILE).delete = MagicMock(
+            return_value=None
+        )
+        gw.delete_object(self.TEST_BUCKET, self.TEST_FILE)
+        gw.client.bucket(self.TEST_BUCKET).blob(self.TEST_FILE).delete.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_copy(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).copy_blob = MagicMock(return_value=None)
+        gw.copy(
+            self.TEST_BUCKET, self.TEST_FILE, self.TEST_BUCKET, f"{self.TEST_FILE}_COPY"
+        )
+        gw.client.bucket(self.TEST_BUCKET).copy_blob.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_object_exists(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.bucket(self.TEST_BUCKET).blob(self.TEST_FILE).exists = MagicMock(
+            return_value=None
+        )
+        gw.object_exists(self.TEST_BUCKET, self.TEST_FILE)
+        gw.client.bucket(self.TEST_BUCKET).blob(self.TEST_FILE).exists.assert_called()
+
+    @patch("google.cloud.storage.Client")
+    def test_list_objects(self, GCSClient):
+        gw = GCSGateway()
+        gw.client = GCSClient()
+        gw.client.list_blobs = MagicMock(return_value=[])
+        gw.list_objects(self.TEST_BUCKET, self.TEST_FILE)
+        gw.client.list_blobs.assert_called()

--- a/tests/service/test_storage_gcs.py
+++ b/tests/service/test_storage_gcs.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fbpcp.service.storage_gcs import GCSStorageService
+
+
+class TestGCSStorageService(unittest.TestCase):
+    TEST_BUCKET = "test-bucket"
+    TEST_FILE = "test-file"
+    TEST_DATA = "this is test data"
+    TEST_LOCAL_DIR = "./"
+    TEST_LOCAL_FILE = "/test-local-file.txt"
+    TEST_REMOTE_FILE = (
+        "https://storage.cloud.google.com/" + TEST_BUCKET + "/" + TEST_FILE
+    )
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_read(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway.get_object = MagicMock(return_value=None)
+        gcs.read(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.get_object.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_write(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway.put_object = MagicMock(return_value=None)
+        gcs.write(self.TEST_REMOTE_FILE, self.TEST_DATA)
+        gcs.gcs_gateway.put_object.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_copy_local_to_gcs(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        # test recursive upload
+        gcs.upload_dir = MagicMock(return_value=None)
+        gcs.copy(self.TEST_LOCAL_FILE, self.TEST_REMOTE_FILE, True)
+        gcs.upload_dir.assert_called()
+        # test non-recursive upload
+        gcs.gcs_gateway.upload_file = MagicMock(return_value=None)
+        gcs.copy(self.TEST_LOCAL_FILE, self.TEST_REMOTE_FILE, False)
+        gcs.gcs_gateway.upload_file.assert_called_with(
+            file_name=str(self.TEST_LOCAL_FILE),
+            bucket=self.TEST_BUCKET,
+            key=self.TEST_FILE,
+        )
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_copy_gcs_to_local(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway.download_file = MagicMock(return_value=None)
+        gcs.copy(self.TEST_REMOTE_FILE, self.TEST_LOCAL_FILE)
+        gcs.gcs_gateway.download_file.assert_called_with(
+            bucket=self.TEST_BUCKET,
+            key=self.TEST_FILE,
+            filename=str(self.TEST_LOCAL_FILE),
+        )
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    @patch("glob.glob", return_value=["test.txt"])
+    @patch("os.path.isfile", return_value=True)
+    def test_upload_dir(self, isfile, glob, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.__check_dir = MagicMock(return_value=None)
+        gcs.gcs_gateway.upload_file = MagicMock(return_value=None)
+        gcs.upload_dir(self.TEST_LOCAL_DIR, self.TEST_BUCKET, self.TEST_FILE)
+        gcs.gcs_gateway.upload_file.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    @patch("os.path.exists", return_value=True)
+    def test_download_dir(self, exists, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.list_objects = MagicMock(return_value=["test.txt"])
+        gcs.gcs_gateway.download_file = MagicMock(return_value=None)
+        gcs.download_dir(self.TEST_BUCKET, self.TEST_FILE, self.TEST_LOCAL_DIR)
+        gcs.gcs_gateway.download_file.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_copy_dir(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.list_objects = MagicMock(return_value=["test.txt"])
+        gcs.gcs_gateway.copy = MagicMock(return_value=None)
+        gcs.copy_dir(
+            self.TEST_BUCKET, self.TEST_FILE, self.TEST_BUCKET, self.TEST_FILE + "2"
+        )
+        gcs.gcs_gateway.copy.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_delete(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.delete_object = MagicMock(return_value=None)
+        gcs.delete(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.delete_object.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_file_exists(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.object_exists = MagicMock(return_value=None)
+        gcs.file_exists(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.object_exists.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_get_file_info(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.get_object_info = MagicMock(return_value={})
+        gcs.get_file_info(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.get_object_info.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_get_file_size(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.get_object_size = MagicMock(return_value=None)
+        gcs.get_file_size(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.get_object_size.assert_called()
+
+    @patch("fbpcp.gateway.gcs.GCSGateway")
+    @patch("google.cloud.storage.Client")
+    def test_list_folders(self, GCSClient, GCSGateway):
+        gcs = GCSStorageService()
+        gcs.gcs_gateway = GCSGateway()
+        gcs.gcs_gateway.list_objects = MagicMock(return_value=["test.txt"])
+        gcs.list_folders(self.TEST_REMOTE_FILE)
+        gcs.gcs_gateway.list_objects.assert_called()

--- a/tests/util/test_gcspath.py
+++ b/tests/util/test_gcspath.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from fbpcp.util.gcspath import GCSPath
+
+
+class TestGCSPath(unittest.TestCase):
+    def test_gcspath_no_subfolder(self):
+        test_gcspath = GCSPath("https://storage.cloud.google.com/bucket-name/key-name")
+        self.assertEqual(test_gcspath.bucket, "bucket-name")
+        self.assertEqual(test_gcspath.key, "key-name")
+
+    def test_gcspath_with_subfoler(self):
+        test_gcspath = GCSPath(
+            "https://storage.cloud.google.com/bucket-name/subfolder/key"
+        )
+        self.assertEqual(test_gcspath.bucket, "bucket-name")
+        self.assertEqual(test_gcspath.key, "subfolder/key")
+
+    def test_gcspath_invalid_fileURL(self):
+        test_url = "an invalid fileURL"
+        with self.assertRaises(ValueError):
+            GCSPath(test_url)


### PR DESCRIPTION
Summary:
# Context
In order to make onedocker runner download binaries from different cloud storages. We need to first oss gcs related modules first.

# Summary
This diff did the moved intern modules to oss folder and add some test cases to ensure the needed coverage

Differential Revision: D32941057

