### PR TITLE
Create a OneDockerPackageRepositoryBuilder to enable GCS support

### DIFF
--- a/onedocker/repository/onedocker_repo_builder.py
+++ b/onedocker/repository/onedocker_repo_builder.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.error.pcp import PcpError
+from fbpcp.service.storage import StorageService, PathType
+from fbpcp.service.storage_gcs import GCSStorageService
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpcp.util.s3path import S3Path
+from onedocker.repository.onedocker_package import OneDockerPackageRepository
+
+
+class OneDockerPackageRepositoryBuilder:
+    # This builder (subject to change) is for supporting multi-cloud in onedocker_runner, which uses the container credentials. (Task role in AWS and workload identity in GCP)
+    @classmethod
+    def create_repository(
+        cls,
+        repository_path: str,
+    ) -> OneDockerPackageRepository:
+        repo_path_type = StorageService.path_type(repository_path)
+        if repo_path_type != PathType.S3 and repo_path_type != PathType.GCS:
+            raise PcpError(f"{repo_path_type.name} repository is not supported yet")
+
+        if repo_path_type == PathType.S3:
+            s3_storage_svc = S3StorageService(S3Path(repository_path).region)
+            return OneDockerPackageRepository(s3_storage_svc, repository_path)
+        else:
+            gcs_storage_svc = GCSStorageService()
+            return OneDockerPackageRepository(gcs_storage_svc, repository_path)

--- a/onedocker/tests/repository/test_onedocker_repo_builder.py
+++ b/onedocker/tests/repository/test_onedocker_repo_builder.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+from fbpcp.service.storage_gcs import GCSStorageService
+from fbpcp.service.storage_s3 import S3StorageService
+from onedocker.repository.onedocker_repo_builder import (
+    OneDockerPackageRepositoryBuilder,
+)
+
+TEST_S3_REPO = "https://bucket-name.s3.us-west-2.amazonaws.com/key"
+TEST_GCS_REPO = "https://storage.cloud.google.com/bucket_name/key"
+
+
+class TestOneDockerPackageRepositoryBuilder(unittest.TestCase):
+    @patch("fbpcp.service.storage_s3.S3Gateway")
+    def test_create_onedocker_s3_repository(self, MockS3Gateway):
+        onedocker_package_repo = OneDockerPackageRepositoryBuilder.create_repository(
+            repository_path=TEST_S3_REPO
+        )
+        self.assertIsInstance(onedocker_package_repo.storage_svc, S3StorageService)
+
+    @patch("fbpcp.service.storage_gcs.GCSGateway")
+    def test_create_onedocker_gcs_repository(self, MockGCSGateway):
+        onedocker_package_repo = OneDockerPackageRepositoryBuilder.create_repository(
+            repository_path=TEST_GCS_REPO
+        )
+        self.assertIsInstance(onedocker_package_repo.storage_svc, GCSStorageService)


### PR DESCRIPTION
Summary:
## Context
OneDockerPackageRepository, depending on storage sercice, is to manage the onedocker packages in different cloud storages. This builder is to provide a factory method so we can have different repository for different cloud storage.

```## use case: In onedocker_runner.py:
onedocker_pkg_repo = OneDockerPackageRepositoryBuilder.create_repository(repository_path)
onedocker_pkg_repo.download(**)
```
## Summary
1. Create the builder and its test

## Next
Integrate it into onedocker_runner

Differential Revision: D32972928

