### PR TITLE
Add get_tasks_count function to container service

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -101,3 +101,11 @@ class ContainerService(abc.ABC):
             describes the error reason.
         """
         pass
+
+    @abc.abstractmethod
+    def get_current_instances_count(self) -> int:
+        """Get total pending and running tasks count for cluster
+        Returns:
+            Integer that represent the total pending and running tasks count for cluster
+        """
+        pass

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -105,3 +105,7 @@ class AWSContainerService(ContainerService):
         """
         s = container_definition.split("#")
         return (s[0], s[1])
+
+    def get_current_instances_count(self) -> int:
+        cluster = self.ecs_gateway.describe_cluster(self.cluster)
+        return cluster.running_tasks + cluster.pending_tasks


### PR DESCRIPTION
Summary: This diff is to add the get_cluster_tasks_count to container_service. This will be used in the new PCECapacityService (D33029888) to return the total counts of tasks that's running or pending. Will implement unit test in later diff once we are align with the function interface.

Differential Revision: D33033424

