### PR TITLE
Add get container function in onedocker service

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -160,6 +160,9 @@ class OneDockerService(MetricsGetter):
     ) -> List[Optional[ContainerInstance]]:
         return self.container_svc.get_instances(instance_ids)
 
+    def get_container(self, instance_id: str) -> Optional[ContainerInstance]:
+        return self.container_svc.get_instance(instance_id)
+
     def _get_exe_name(self, package_name: str) -> str:
         return package_name.split("/")[1]
 

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -118,6 +118,19 @@ class TestOneDockerServiceSync(unittest.TestCase):
         self.metrics.count.assert_any_call(METRICS_START_CONTAINERS_COUNT, 1)
         self.metrics.gauge.assert_called_with(METRICS_START_CONTAINERS_DURATION, ANY)
 
+    def test_get_container(self):
+        # Arrange
+        expected_results = _get_pending_container_instances()[0]
+
+        self.container_svc.get_instance = MagicMock(return_value=expected_results)
+
+        # Act
+        container = self.onedocker_svc.get_container(TEST_INSTANCE_ID_1)
+
+        # Assert
+        self.assertEqual(container, expected_results)
+        self.container_svc.get_instance.assert_called_with(TEST_INSTANCE_ID_1)
+
 
 class TestOneDockerServiceAsync(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")


### PR DESCRIPTION
Summary: What: Add method to get one container from onedocker service. This will benefit the PCE service. In PCE service we always want to check the status of single container for tracking the deployment/delete progress.

Differential Revision: D33037906

