### PR TITLE
Refactor fbpcp modules to support GCP

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -11,7 +11,7 @@ import logging
 from typing import Dict, List, Optional, Final
 
 from fbpcp.decorator.metrics import request_counter, duration_time, error_counter
-from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.metrics.getter import MetricsGetter
@@ -142,10 +142,7 @@ class OneDockerService(MetricsGetter):
         self, container_id: str
     ) -> Optional[ContainerInstance]:
         updated_container = self.get_containers([container_id])[0]
-        while (
-            updated_container is None
-            or updated_container.status is ContainerInstanceStatus.UNKNOWN
-        ):
+        while not updated_container or not updated_container.ip_address:
             await asyncio.sleep(1)
             updated_container = self.get_containers([container_id])[0]
             if updated_container is None:


### PR DESCRIPTION
Summary:
# Context
Some modules with fbpcp needs some updates to support GCP:
1. k8s.py:
   1. The default namespace should be onedocker, which is defined in terraform scripts.
   2. Env should be appended into yaml file

2. Added other parameters in k8s_job_spec.yaml, which are required by GKE cluster

3. The logic of wait_for_pending_containers is: we will return the container instance only if the ip address is not none.

Differential Revision: D33080060

