### PR TITLE
Refactor the waiting logic for pending containers

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -11,7 +11,7 @@ import logging
 from typing import Dict, List, Optional, Final
 
 from fbpcp.decorator.metrics import request_counter, duration_time, error_counter
-from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.error.pcp import PcpError
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.metrics.getter import MetricsGetter
@@ -142,7 +142,11 @@ class OneDockerService(MetricsGetter):
         self, container_id: str
     ) -> Optional[ContainerInstance]:
         updated_container = self.get_containers([container_id])[0]
-        while not updated_container or not updated_container.ip_address:
+        while (
+            not updated_container
+            or not updated_container.ip_address
+            or updated_container.status is ContainerInstanceStatus.UNKNOWN
+        ):
             await asyncio.sleep(1)
             updated_container = self.get_containers([container_id])[0]
             if updated_container is None:


### PR DESCRIPTION
Summary: We only wait until the container has the ip address, however, this might be enough.

Reviewed By: taoyong-ty

Differential Revision: D33151584

