### PR TITLE
Make sure not all errors are swallowed

### DIFF
--- a/fbpcp/gateway/s3.py
+++ b/fbpcp/gateway/s3.py
@@ -10,6 +10,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 import boto3
+from botocore.exceptions import ClientError
 from fbpcp.decorator.error_handler import error_handler
 from fbpcp.gateway.aws import AWSGateway
 from tqdm.auto import tqdm
@@ -106,8 +107,11 @@ class S3Gateway(AWSGateway):
             # Result intentionally discarded
             _ = self.client.head_object(Bucket=bucket, Key=key)
             return True
-        except Exception:
-            return False
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "404":
+                return False
+            else:
+                raise
 
     @error_handler
     def copy(

--- a/tests/gateway/test_s3.py
+++ b/tests/gateway/test_s3.py
@@ -7,94 +7,112 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from botocore.exceptions import ClientError
+from fbpcp.error.pcp import PcpError
 from fbpcp.gateway.s3 import S3Gateway
+
+TEST_LOCAL_FILE = "test-local-file"
+TEST_BUCKET = "test-bucket"
+TEST_FILE = "test-file"
+TEST_ACCESS_KEY_ID = "test-access-key-id"
+TEST_ACCESS_KEY_DATA = "test-access-key-data"
+TEST_S3_OPERATION = "head_object"
+REGION = "us-west-1"
 
 
 class TestS3Gateway(unittest.TestCase):
-    TEST_LOCAL_FILE = "test-local-file"
-    TEST_BUCKET = "test-bucket"
-    TEST_FILE = "test-file"
-    TEST_ACCESS_KEY_ID = "test-access-key-id"
-    TEST_ACCESS_KEY_DATA = "test-access-key-data"
-    REGION = "us-west-1"
-
     @patch("boto3.client")
     def test_create_bucket(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.create_bucket = MagicMock(return_value=None)
-        gw.create_bucket(self.TEST_BUCKET)
+        gw.create_bucket(TEST_BUCKET)
         gw.client.create_bucket.assert_called()
 
     @patch("boto3.client")
     def test_delete_bucket(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.delete_bucket = MagicMock(return_value=None)
-        gw.delete_bucket(self.TEST_BUCKET)
+        gw.delete_bucket(TEST_BUCKET)
         gw.client.delete_bucket.assert_called()
 
     @patch("boto3.client")
     def test_put_object(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.put_object = MagicMock(return_value=None)
-        gw.put_object(
-            self.TEST_BUCKET, self.TEST_ACCESS_KEY_ID, self.TEST_ACCESS_KEY_DATA
-        )
+        gw.put_object(TEST_BUCKET, TEST_ACCESS_KEY_ID, TEST_ACCESS_KEY_DATA)
         gw.client.put_object.assert_called()
 
     @patch("os.path.getsize", return_value=100)
     @patch("boto3.client")
     def test_upload_file(self, BotoClient, mock_getsize):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.upload_file = MagicMock(return_value=None)
-        gw.upload_file(self.TEST_LOCAL_FILE, self.TEST_BUCKET, self.TEST_FILE)
+        gw.upload_file(TEST_LOCAL_FILE, TEST_BUCKET, TEST_FILE)
         gw.client.upload_file.assert_called()
 
     @patch("boto3.client")
     def test_download_file(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.head_object.return_value = {"ContentLength": 100}
         gw.client.download_file = MagicMock(return_value=None)
-        gw.download_file(self.TEST_BUCKET, self.TEST_FILE, self.TEST_LOCAL_FILE)
+        gw.download_file(TEST_BUCKET, TEST_FILE, TEST_LOCAL_FILE)
         gw.client.download_file.assert_called()
 
     @patch("boto3.client")
     def test_delete_object(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.delete_object = MagicMock(return_value=None)
-        gw.delete_object(self.TEST_BUCKET, self.TEST_FILE)
+        gw.delete_object(TEST_BUCKET, TEST_FILE)
         gw.client.delete_object.assert_called()
 
     @patch("boto3.client")
     def test_copy(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.copy = MagicMock(return_value=None)
-        gw.copy(
-            self.TEST_BUCKET, self.TEST_FILE, self.TEST_BUCKET, f"{self.TEST_FILE}_COPY"
-        )
+        gw.copy(TEST_BUCKET, TEST_FILE, TEST_BUCKET, f"{TEST_FILE}_COPY")
         gw.client.copy.assert_called()
 
     @patch("boto3.client")
     def test_object_exists(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.head_object = MagicMock(return_value=None)
-        self.assertTrue(gw.object_exists(self.TEST_BUCKET, self.TEST_ACCESS_KEY_ID))
+        self.assertTrue(gw.object_exists(TEST_BUCKET, TEST_ACCESS_KEY_ID))
         gw.client.head_object.assert_called()
 
     @patch("boto3.client")
     def test_object_not_exists(self, BotoClient):
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
-        gw.client.head_object = MagicMock(side_effect=Exception)
-        self.assertFalse(gw.object_exists(self.TEST_BUCKET, self.TEST_ACCESS_KEY_ID))
+        error_response = {"Error": {"Code": "404", "Message": "Not Found"}}
+        gw.client.head_object = MagicMock(
+            side_effect=ClientError(error_response, TEST_S3_OPERATION)
+        )
+        self.assertFalse(gw.object_exists(TEST_BUCKET, TEST_ACCESS_KEY_ID))
         gw.client.head_object.assert_called()
+
+    @patch("boto3.client")
+    def test_object_exists_exception(self, BotoClient):
+        gw = S3Gateway(REGION)
+        gw.client = BotoClient()
+        error_code = "403"
+        error_msg = "Permission denied"
+        error_response = {"Error": {"Code": error_code, "Message": error_msg}}
+        gw.client.head_object = MagicMock(
+            side_effect=ClientError(error_response, TEST_S3_OPERATION)
+        )
+        with self.assertRaises(
+            PcpError,
+            msg=f"An error occurred ({error_code}) when calling the {TEST_S3_OPERATION} operation: {error_msg}",
+        ):
+            gw.object_exists(TEST_BUCKET, TEST_ACCESS_KEY_ID)
 
     @patch("boto3.client")
     def test_list_object2(self, BotoClient):
@@ -108,12 +126,12 @@ class TestS3Gateway(unittest.TestCase):
                 ],
             }
         ]
-        gw = S3Gateway(self.REGION)
+        gw = S3Gateway(REGION)
         gw.client = BotoClient()
         gw.client.get_paginator("list_objects_v2").paginate = MagicMock(
             return_value=client_return_response
         )
-        key_list = gw.list_object2(self.TEST_BUCKET, self.TEST_ACCESS_KEY_ID)
+        key_list = gw.list_object2(TEST_BUCKET, TEST_ACCESS_KEY_ID)
         expected_key_list = [
             test_page_content_key1,
             test_page_content_key2,


### PR DESCRIPTION
Summary:
## Context
Currently the error messages when s3 gateway checks whether an object exists are all swallowed. See https://fb.workplace.com/groups/331044242148818/permalink/387504849836090/

## Summary
This diff makes sure the function only returns false when the object or bucket does not exist.

Differential Revision: D33240701

