### PR TITLE
Fix no module found error

### DIFF
--- a/pce/entity/__init__.py
+++ b/pce/entity/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
When adversiter installed fbpcp and use pce validator, they got an error "ModuleNotFoundError: No module named 'pce.entity"

see: P472556301

This is due to a missing init file under entity folder

Differential Revision: D33302929

