### PR TITLE
Update container service to take larger data input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,10 @@ Release PCE validator and update onedocker dependencies
 
 ### Description of changes
 * Update the version of dependencies to make them internally consistent and Fix the docker image vulnerables
+
+## 0.2.2 -> 0.2.3
+### Types of changes
+* New feature (non-breaking change which adds functionality)
+
+### Description of changes
+* API change: start_containers and get_containers now support up tp 1000 concurrent containers

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -101,6 +101,20 @@ class OneDockerService(MetricsGetter):
         task_definition -- if specified, overrides OneDockerService's task definition
                            when starting this container
         """
+        """Spin up cloud containers according to command arg list.
+
+        Args:
+            package_name:       Name of running package within docker image
+            task_definition:    Task definition required by docker containers. If specified, overrides OneDockerService's task definition
+                                when starting this container
+            cmd_args_list:      A list of command overrides in docker containers
+            env_vars:           environment variable overrides in docker containers
+            timeout:            container timeout. If specified, docker container would be forced to stop
+            tag:                Tag for docker containers
+
+        Returns:
+            A list of the containers that were successfuly started
+        """
         if not cmd_args_list:
             raise ValueError("Command Argument List shouldn't be None or Empty")
 
@@ -159,6 +173,17 @@ class OneDockerService(MetricsGetter):
     def get_containers(
         self, instance_ids: List[str]
     ) -> List[Optional[ContainerInstance]]:
+        # TODO We will need long term discussion on the container capacity of onedocker
+        """Get one or more container instances
+
+        Args:
+            instance_ids: a list of the container instances.
+
+        Returns:
+            A list of Optional, in the same order as the input ids. For example, if
+            users pass 3 instance_ids and the second instance could not be found,
+            then returned list should also have 3 elements, with the 2nd elements being None.
+        """
         return self.container_svc.get_instances(instance_ids)
 
     def get_container(self, instance_id: str) -> Optional[ContainerInstance]:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.2",
+    version="0.2.3",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -131,6 +131,23 @@ class TestOneDockerServiceSync(unittest.TestCase):
         self.assertEqual(container, expected_results)
         self.container_svc.get_instance.assert_called_with(TEST_INSTANCE_ID_1)
 
+    def test_get_containers(self):
+        # Arrange
+        expected_results = _get_pending_container_instances()
+
+        self.container_svc.get_instances = MagicMock(return_value=expected_results)
+
+        # Act
+        containers = self.onedocker_svc.get_containers(
+            [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        )
+
+        # Assert
+        self.assertEqual(containers, expected_results)
+        self.container_svc.get_instances.assert_called_with(
+            [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        )
+
 
 class TestOneDockerServiceAsync(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")


### PR DESCRIPTION
Summary:
## Context
AWS has one undocumented limit that describe_tasks can only support up to 100 tasks. This will block requests that require more than 100 containers. We need shard the input task list and call the API for multiple times.

## Summary
* Shard the input instance_ids in onedocker get_containers and make sure the size of each shard won't beyond 100.
* Add validation check that start_containers and get_containers can only support 1000 capacity

Differential Revision: D33542208

