### PR TITLE
Update container service to take larger data input (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,10 @@ Release PCE validator and update onedocker dependencies
 
 ### Description of changes
 * Update the version of dependencies to make them internally consistent and Fix the docker image vulnerables
+
+## 0.2.2 -> 0.2.3
+### Types of changes
+* New feature (non-breaking change which adds functionality)
+
+### Description of changes
+* API change: start_containers and get_containers now support up tp 1000 concurrent containers

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -15,6 +15,8 @@ from fbpcp.gateway.ecs import ECSGateway
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.service.container import ContainerService
 
+AWS_API_INPUT_SIZE_LIMIT = 100  # AWS API Call Capacity Limit
+
 
 class AWSContainerService(ContainerService):
     def __init__(
@@ -84,7 +86,24 @@ class AWSContainerService(ContainerService):
     def get_instances(
         self, instance_ids: List[str]
     ) -> List[Optional[ContainerInstance]]:
-        return self.ecs_gateway.describe_tasks(self.cluster, instance_ids)
+        """Get one or more container instances
+
+        Args:
+            instance_ids: a list of the container instances.
+
+        Returns:
+            A list of Optional, in the same order as the input ids. For example, if
+            users pass 3 instance_ids and the second instance could not be found,
+            then returned list should also have 3 elements, with the 2nd elements being None.
+        """
+        id_batches = [
+            instance_ids[i : i + AWS_API_INPUT_SIZE_LIMIT]
+            for i in range(0, len(instance_ids), AWS_API_INPUT_SIZE_LIMIT)
+        ]
+        container_batches = [
+            self.ecs_gateway.describe_tasks(self.cluster, ids) for ids in id_batches
+        ]
+        return sum(container_batches, [])
 
     def cancel_instance(self, instance_id: str) -> None:
         return self.ecs_gateway.stop_task(cluster=self.cluster, task_id=instance_id)

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -101,6 +101,20 @@ class OneDockerService(MetricsGetter):
         task_definition -- if specified, overrides OneDockerService's task definition
                            when starting this container
         """
+        """Spin up cloud containers according to command arg list.
+
+        Args:
+            package_name:       Name of running package within docker image
+            task_definition:    Task definition required by docker containers. If specified, overrides OneDockerService's task definition
+                                when starting this container
+            cmd_args_list:      A list of command overrides in docker containers
+            env_vars:           environment variable overrides in docker containers
+            timeout:            container timeout. If specified, docker container would be forced to stop
+            tag:                Tag for docker containers
+
+        Returns:
+            A list of the containers that were successfuly started
+        """
         if not cmd_args_list:
             raise ValueError("Command Argument List shouldn't be None or Empty")
 
@@ -159,6 +173,17 @@ class OneDockerService(MetricsGetter):
     def get_containers(
         self, instance_ids: List[str]
     ) -> List[Optional[ContainerInstance]]:
+        # TODO We will need long term discussion on the container capacity of onedocker
+        """Get one or more container instances
+
+        Args:
+            instance_ids: a list of the container instances.
+
+        Returns:
+            A list of Optional, in the same order as the input ids. For example, if
+            users pass 3 instance_ids and the second instance could not be found,
+            then returned list should also have 3 elements, with the 2nd elements being None.
+        """
         return self.container_svc.get_instances(instance_ids)
 
     def get_container(self, instance_id: str) -> Optional[ContainerInstance]:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.2",
+    version="0.2.3",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -4,13 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
+from uuid import uuid4
 
 from fbpcp.entity.cluster_instance import Cluster
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.error.pcp import PcpError
-from fbpcp.service.container_aws import AWSContainerService
+from fbpcp.service.container_aws import AWSContainerService, AWS_API_INPUT_SIZE_LIMIT
 
 TEST_INSTANCE_ID_1 = "test-instance-id-1"
 TEST_INSTANCE_ID_2 = "test-instance-id-2"
@@ -95,23 +97,50 @@ class TestAWSContainerService(unittest.TestCase):
         self.assertEqual(instance, container_instance)
 
     def test_get_instances(self):
+        # Arrange
+        num_instances = 134
+        instance_ids = [uuid4() for _ in range(num_instances)]
         container_instances = [
             ContainerInstance(
-                TEST_INSTANCE_ID_1,
-                TEST_IP_ADDRESS,
-                ContainerInstanceStatus.STARTED,
-            ),
+                instance_id, TEST_IP_ADDRESS, ContainerInstanceStatus.UNKNOWN
+            )
+            for instance_id in instance_ids
+        ]
+        expected_container_shard_0 = [
             ContainerInstance(
-                TEST_INSTANCE_ID_2,
-                TEST_IP_ADDRESS,
-                ContainerInstanceStatus.STARTED,
+                instance_id, TEST_IP_ADDRESS, ContainerInstanceStatus.UNKNOWN
+            )
+            for instance_id in instance_ids[0:AWS_API_INPUT_SIZE_LIMIT]
+        ]
+        expected_container_shard_1 = [
+            ContainerInstance(
+                instance_id, TEST_IP_ADDRESS, ContainerInstanceStatus.UNKNOWN
+            )
+            for instance_id in instance_ids[AWS_API_INPUT_SIZE_LIMIT:num_instances]
+        ]
+
+        self.container_svc.ecs_gateway.describe_tasks = MagicMock(
+            side_effect=[expected_container_shard_0, expected_container_shard_1]
+        )
+
+        calls = [
+            call(self.container_svc.cluster, instance_ids[0:AWS_API_INPUT_SIZE_LIMIT]),
+            call(
+                self.container_svc.cluster,
+                instance_ids[AWS_API_INPUT_SIZE_LIMIT:num_instances],
             ),
         ]
-        self.container_svc.ecs_gateway.describe_tasks = MagicMock(
-            return_value=container_instances
+
+        # Act
+        instances = self.container_svc.get_instances(instance_ids=instance_ids)
+
+        # Assert
+        self.container_svc.ecs_gateway.describe_tasks.assert_has_calls(
+            calls, any_order=False
         )
-        instances = self.container_svc.get_instances(
-            [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        self.assertEqual(
+            self.container_svc.ecs_gateway.describe_tasks.call_count,
+            math.ceil(num_instances / AWS_API_INPUT_SIZE_LIMIT),
         )
         self.assertEqual(instances, container_instances)
 

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -131,6 +131,23 @@ class TestOneDockerServiceSync(unittest.TestCase):
         self.assertEqual(container, expected_results)
         self.container_svc.get_instance.assert_called_with(TEST_INSTANCE_ID_1)
 
+    def test_get_containers(self):
+        # Arrange
+        expected_results = _get_pending_container_instances()
+
+        self.container_svc.get_instances = MagicMock(return_value=expected_results)
+
+        # Act
+        containers = self.onedocker_svc.get_containers(
+            [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        )
+
+        # Assert
+        self.assertEqual(containers, expected_results)
+        self.container_svc.get_instances.assert_called_with(
+            [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        )
+
 
 class TestOneDockerServiceAsync(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcp/pull/231

## Context
AWS has one undocumented limit that describe_tasks can only support up to 100 tasks. This will block requests that require more than 100 containers. We need shard the input task list and call the API for multiple times.

## Summary
* Shard the input instance_ids in onedocker get_containers and make sure the size of each shard won't beyond 100.
* Add validation check that start_containers and get_containers can only support 1000 capacity

Differential Revision: D33542208

