### PR TITLE
Adding validator for Cloudwatch logs

### DIFF
--- a/pce/entity/log_group_aws.py
+++ b/pce/entity/log_group_aws.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LogGroup:
+    log_group_name: str

--- a/pce/gateway/logs_aws.py
+++ b/pce/gateway/logs_aws.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional, Dict, Any
+
+import boto3
+import botocore
+from fbpcp.gateway.aws import AWSGateway
+from pce.entity.log_group_aws import LogGroup
+
+
+class LogsGateway(AWSGateway):
+    def __init__(
+        self,
+        region: str,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(region, access_key_id, access_key_data, config)
+
+        self.client: botocore.client.BaseClient = boto3.client(
+            "logs", region_name=self.region, **self.config
+        )
+
+    def describe_log_group(self, log_group_name: str) -> Optional[LogGroup]:
+        response = self.client.describe_log_groups(logGroupNamePrefix=log_group_name)
+        """
+        Only 1 log group name will be expected in this case
+        Though this API returns up to 50 matches and a nextToken is required for pagination,  the first match will be the exact log_group_name
+        """
+        for group in response["logGroups"]:
+            if group["logGroupName"] == log_group_name:
+                log_group = LogGroup(log_group_name=group["logGroupName"])
+                return log_group

--- a/pce/gateway/tests/test_logs_aws.py
+++ b/pce/gateway/tests/test_logs_aws.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from pce.entity.log_group_aws import LogGroup
+from pce.gateway.logs_aws import LogsGateway
+
+
+class TestLogsGateway(TestCase):
+    REGION = "us-west-1"
+    TEST_LOG_GROUP_NAME = "/ecs/test-log-group-name"
+    TEST_LOG_GROUP_ARN = (
+        f"arn:aws:logs:{REGION}:123456789012:log-group:{TEST_LOG_GROUP_NAME}:*"
+    )
+    TEST_ADDITIONAL_LOG_GROUP_NAME = "/ecs/test-log_group-name"
+    TEST_ADDITIONAL_LOG_GROUP_ARN = (
+        f"arn:aws:logs:{REGION}:123456789012:log-group:{TEST_LOG_GROUP_NAME}:*"
+    )
+
+    @patch("boto3.client")
+    def setUp(self, mock_boto_client: MagicMock) -> None:
+        self.aws_logs = MagicMock()
+        mock_boto_client.return_value = self.aws_logs
+        self.logs = LogsGateway(region=self.REGION)
+
+    def test_describe_log_group(self) -> None:
+        test_log_groups_response = {
+            "logGroups": [
+                {
+                    "logGroupName": self.TEST_LOG_GROUP_NAME,
+                    "creationTime": 1640137658065,
+                    "metricFilterCount": 0,
+                    "arn": self.TEST_LOG_GROUP_ARN,
+                    "storedBytes": 0,
+                },
+                {
+                    "logGroupName": self.TEST_ADDITIONAL_LOG_GROUP_NAME,
+                    "creationTime": 1633025558042,
+                    "metricFilterCount": 0,
+                    "arn": self.TEST_ADDITIONAL_LOG_GROUP_ARN,
+                    "storedBytes": 980,
+                },
+            ]
+        }
+        self.aws_logs.describe_log_groups = MagicMock(
+            return_value=test_log_groups_response
+        )
+        exist_log_group = self.logs.describe_log_group(
+            log_group_name=self.TEST_LOG_GROUP_NAME
+        )
+
+        expected_log_group = LogGroup(
+            log_group_name=self.TEST_LOG_GROUP_NAME,
+        )
+
+        self.assertEqual(exist_log_group, expected_log_group)
+        self.aws_logs.describe_log_group.assert_called


### PR DESCRIPTION
Summary:
This validator check is to check if there are cloudwatch logs are configured properly.
1. Since CloudWatch logs does not support API to describe log group with a given tag, instead I need to: extract the log group name from task definition  and validate if this log group exist

2. Cloud Watch logs is not part of PCE and missing logs wont stop the study from running, as such all the errors are under Warning Category.

Differential Revision: D33712270

