### PR TITLE
Fix AWS VPC local route being parsed as RouteTargetType.INTERNET

### DIFF
--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -124,7 +124,7 @@ def map_ec2route_to_route(route: Dict[str, Any]) -> Route:
     if "VpcPeeringConnectionId" in route:
         route_target_type = RouteTargetType.VPC_PEERING
         route_target_id = route["VpcPeeringConnectionId"]
-    elif "GatewayId" in route:
+    elif "GatewayId" in route and route["GatewayId"].startswith("igw-"):
         route_target_type = RouteTargetType.INTERNET
         route_target_id = route["GatewayId"]
     state = RouteState.UNKNOWN

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -35,7 +35,6 @@ from pce.validator.pce_standard_constants import (
     FIREWALL_RULE_FINAL_PORT,
     FIREWALL_RULE_INITIAL_PORT,
     IGW_ROUTE_DESTINATION_CIDR_BLOCK,
-    IGW_ROUTE_TARGET_PREFIX,
     TASK_POLICY,
 )
 
@@ -282,9 +281,6 @@ class ValidationSuite:
         for route in route_table.routes:
             if (
                 route.route_target.route_target_type == RouteTargetType.INTERNET
-                and route.route_target.route_target_id.startswith(
-                    IGW_ROUTE_TARGET_PREFIX
-                )
                 and route.destination_cidr_block == IGW_ROUTE_DESTINATION_CIDR_BLOCK
             ):
                 igw_route = route


### PR DESCRIPTION
Summary:
In fbpcp/mapper/aws.py, the code mapping response from AWS to fbpcp representation would falsely mark a local route as RouteTargetType.INTERNET, because of presence of 'GatewayId' key in the response. See sample responses below for a local and an internet gateway route

```
route dict from AWS response for local route: {'DestinationCidrBlock': '10.0.0.0/16', 'GatewayId': 'local', 'Origin': 'CreateRouteTable', 'State': 'active'}
route dict from AWS response for internet gateway route: {'DestinationCidrBlock': '0.0.0.0/0', 'GatewayId': 'igw-09eafec4c3e694b61', 'Origin': 'CreateRoute', 'State': 'active'}
```

This diff fixes the parsing logic to start marking the local route as RouteTargetType.OTHER and only mark as RouteTargetType.INTERNET when the target "GatewayId" begins with "igw-", the AWS convention for Internet Gateway resource targets.

Differential Revision: D33719686

