### PR TITLE
Rename *Gateway classes in pce.gateway prefixing with PCE to differentiate from those in fbpcp.gateway

### DIFF
--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -11,7 +11,7 @@ import boto3
 from fbpcp.gateway.aws import AWSGateway
 
 
-class EC2Gateway(AWSGateway):
+class PCEEC2Gateway(AWSGateway):
     def __init__(
         self,
         region: str,

--- a/pce/gateway/iam.py
+++ b/pce/gateway/iam.py
@@ -18,7 +18,7 @@ from pce.entity.iam_role import (
 from pce.mapper.aws import map_attachedrolepolicies_to_rolepolicies
 
 
-class IAMGateway(AWSGateway):
+class PCEIAMGateway(AWSGateway):
     def __init__(
         self,
         region: str,

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -10,17 +10,17 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from pce.gateway.ec2 import EC2Gateway
+from pce.gateway.ec2 import PCEEC2Gateway
 
 REGION = "us-west-2"
 
 
-class TestEC2Gateway(TestCase):
+class TestPCEEC2Gateway(TestCase):
     def setUp(self) -> None:
         self.aws_ec2 = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_ec2
-            self.ec2 = EC2Gateway(REGION)
+            self.ec2 = PCEEC2Gateway(REGION)
 
     def test_describe_availability_zones(self) -> None:
         client_return_response = {

--- a/pce/gateway/tests/test_iam.py
+++ b/pce/gateway/tests/test_iam.py
@@ -12,17 +12,17 @@ from unittest.mock import patch, call, MagicMock
 from pce.entity.iam_role import (
     IAMRole,
 )
-from pce.gateway.iam import IAMGateway
+from pce.gateway.iam import PCEIAMGateway
 
 REGION = "us-west-2"
 
 
-class TestIAMGateway(TestCase):
+class TestPCEIAMGateway(TestCase):
     def setUp(self) -> None:
         self.aws_iam = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_iam
-            self.iam = IAMGateway(REGION)
+            self.iam = PCEIAMGateway(REGION)
 
     def test_get_policies_for_role(self) -> None:
         test_role_name_1 = "test_role_1"
@@ -107,7 +107,7 @@ class TestIAMGateway(TestCase):
 
         mock_paginator.paginate.assert_has_calls(
             [
-                call(RoleName=IAMGateway._role_id_to_name(test_role_name))
+                call(RoleName=PCEIAMGateway._role_id_to_name(test_role_name))
                 for test_role_name in test_expected_role_attached_policies.keys()
             ]
         )
@@ -115,13 +115,17 @@ class TestIAMGateway(TestCase):
     def test_role_id_to_name_slashes(self) -> None:
         role_name = "application_abc/component_xyz/RDSAccess"
         self.assertEqual(
-            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
+            PCEIAMGateway._role_id_to_name(
+                f"arn:aws:iam::123456789012:role/{role_name}"
+            ),
             role_name,
         )
 
     def test_role_id_to_name_no_slashes(self) -> None:
         role_name = "RDSAccess"
         self.assertEqual(
-            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
+            PCEIAMGateway._role_id_to_name(
+                f"arn:aws:iam::123456789012:role/{role_name}"
+            ),
             role_name,
         )

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -19,8 +19,8 @@ from fbpcp.entity.route_table import Route, RouteState, RouteTargetType
 from fbpcp.entity.vpc_instance import Vpc
 from fbpcp.entity.vpc_peering import VpcPeeringState
 from fbpcp.service.pce_aws import PCE_ID_KEY
-from pce.gateway.ec2 import EC2Gateway
-from pce.gateway.iam import IAMGateway
+from pce.gateway.ec2 import PCEEC2Gateway
+from pce.gateway.iam import PCEIAMGateway
 from pce.validator.message_templates import (
     ValidationErrorDescriptionTemplate,
     ValidationErrorSolutionHintTemplate,
@@ -71,13 +71,13 @@ class ValidationSuite:
         key_id: Optional[str] = None,
         key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
-        ec2_gateway: Optional[EC2Gateway] = None,
-        iam_gateway: Optional[IAMGateway] = None,
+        ec2_gateway: Optional[PCEEC2Gateway] = None,
+        iam_gateway: Optional[PCEIAMGateway] = None,
     ) -> None:
-        self.ec2_gateway: EC2Gateway = ec2_gateway or EC2Gateway(
+        self.ec2_gateway: PCEEC2Gateway = ec2_gateway or PCEEC2Gateway(
             region, key_id, key_data, config
         )
-        self.iam_gateway: IAMGateway = iam_gateway or IAMGateway(
+        self.iam_gateway: PCEIAMGateway = iam_gateway or PCEIAMGateway(
             region, key_id, key_data, config
         )
 


### PR DESCRIPTION
Summary:
Gateway classes under pce.gateway module are created for specific use for code under PCE module, for eg in pce.validator. However, the classes are named same as some gateway classes under fbpcp.gateway module. Renaming pce.gateway classes to prefix with "PCE" to avoid any possibility of confusion.

This is a refactor change - relying mainly on unit tests for testing.

Differential Revision: D33781054

