### PR TITLE
Move split_container_definition to util folder

### DIFF
--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -7,13 +7,14 @@
 # pyre-strict
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.gateway.ecs import ECSGateway
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.service.container import ContainerService
+from fbpcp.util.aws import split_container_definition
 
 AWS_API_INPUT_SIZE_LIMIT = 100  # AWS API Call Capacity Limit
 
@@ -53,9 +54,7 @@ class AWSContainerService(ContainerService):
         cmd: str,
         env_vars: Optional[Dict[str, str]] = None,
     ) -> ContainerInstance:
-        task_definition, container = self._split_container_definition(
-            container_definition
-        )
+        task_definition, container = split_container_definition(container_definition)
 
         if not self.subnets:
             raise PcpError(
@@ -117,13 +116,6 @@ class AWSContainerService(ContainerService):
                 res.append(err)
 
         return res
-
-    def _split_container_definition(self, container_definition: str) -> Tuple[str, str]:
-        """
-        container_definition = task_definition#container
-        """
-        s = container_definition.split("#")
-        return (s[0], s[1])
 
     def get_current_instances_count(self) -> int:
         cluster = self.ecs_gateway.describe_cluster(self.cluster)

--- a/fbpcp/util/aws.py
+++ b/fbpcp/util/aws.py
@@ -8,7 +8,7 @@
 
 
 from functools import reduce
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 def convert_dict_to_list(
@@ -81,3 +81,14 @@ def convert_vpc_tags_to_filter(
 def get_container_definition_id(task_definition_id: str, container: str) -> str:
     # the reverse logic from https://fburl.com/code/ycdjih3q
     return f"{task_definition_id}#{container}"
+
+
+def split_container_definition(container_definition: str) -> Tuple[str, str]:
+    """
+    container_definition = task_definition#container
+    task_definition: ECS task definition, e.g. test-definition:1
+    container: ECS cluster name, e.g. test-cluster
+    example: test-definition:1#test-cluster
+    """
+    s = container_definition.split("#")
+    return (s[0], s[1])


### PR DESCRIPTION
Summary: Context from D33712270, PCE validator needs to use this split_container_definition() to get task definition. I added a similar function for PCE validator, but this duplicate code will add efforts when the containerID format changes. As such, I moved this function under util folder so I can reuse this function for PCE validator

Differential Revision: D33860278

