### PR TITLE
Add PCEECSGateway (2/n)

### DIFF
--- a/pce/gateway/ecs.py
+++ b/pce/gateway/ecs.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional, Dict, Any
+
+import boto3
+import botocore
+from fbpcp.gateway.aws import AWSGateway
+from fbpcp.util.aws import split_container_definition
+from pce.mapper.aws import map_ecstaskdefinition_to_awslogsgroupname
+
+
+class ECSGateway(AWSGateway):
+    def __init__(
+        self,
+        region: str,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(region, access_key_id, access_key_data, config)
+
+        self.client: botocore.client.BaseClient = boto3.client(
+            "ecs", region_name=self.region, **self.config
+        )
+
+    def extract_log_group_name(self, container_definition_id: str) -> Optional[str]:
+        task_definition_arn = split_container_definition(container_definition_id)[0]
+
+        response = self.client.describe_task_definition(
+            taskDefinition=task_definition_arn
+        )
+        log_group_name = map_ecstaskdefinition_to_awslogsgroupname(
+            response["taskDefinition"]
+        )
+        return log_group_name

--- a/pce/gateway/tests/test_ecs.py
+++ b/pce/gateway/tests/test_ecs.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from pce.gateway.ecs import ECSGateway
+
+
+class TestECSGateway(TestCase):
+    REGION = "us-west-1"
+    TEST_LOG_GROUP = "ecs/test-log-group-name"
+    TEST_TASK_ARN = (
+        "arn:aws:ecs:us-west-1:123456789012:task-definition/test-definition:1"
+    )
+    TEST_CONTAINER_ID = f"{TEST_TASK_ARN}#test-container"
+
+    @patch("boto3.client")
+    def setUp(self, mock_boto_client: MagicMock) -> None:
+        self.aws_ecs = MagicMock()
+        mock_boto_client.return_value = self.aws_ecs
+        self.ecs = ECSGateway(region=self.REGION)
+
+    def test_extract_log_group_name(self) -> None:
+        # Arrange
+        test_definition_response = {
+            "taskDefinition": {
+                "taskDefinitionArn": self.TEST_TASK_ARN,
+                "containerDefinitions": [
+                    # the following container parameters are listed in https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
+                    {
+                        "name": "test-container",
+                        "image": "test-image:latest",
+                        "cpu": 4096,
+                        "memory": 30720,
+                        "portMappings": [],
+                        "essential": "true",
+                        "entryPoint": ["sh", "-c"],
+                        "environment": [],
+                        "mountPoints": [],
+                        "volumesFrom": [],
+                        "logConfiguration": {
+                            "logDriver": "awslogs",
+                            "options": {
+                                "awslogs-group": self.TEST_LOG_GROUP,
+                                "awslogs-region": self.REGION,
+                                "awslogs-stream-prefix": "ecs",
+                            },
+                        },
+                    }
+                ],
+            }
+        }
+
+        self.aws_ecs.describe_task_definition = MagicMock(
+            return_value=test_definition_response
+        )
+
+        # Act
+        log_group_name = self.ecs.extract_log_group_name(
+            container_definition_id=self.TEST_CONTAINER_ID
+        )
+
+        # Assert
+        self.assertEqual(log_group_name, self.TEST_LOG_GROUP)
+        self.aws_ecs.describe_task_definition.assert_called()
+
+    def test_extract_nonexist_log_group_name(self) -> None:
+        # Arrange
+        test_definition__no_log_response = {
+            "taskDefinition": {
+                "taskDefinitionArn": self.TEST_TASK_ARN,
+                "containerDefinitions": [
+                    {
+                        "name": "test-container",
+                        "image": "test-image:latest",
+                        "cpu": 4096,
+                        "memory": 30720,
+                        "portMappings": [],
+                        "essential": "true",
+                        "entryPoint": ["sh", "-c"],
+                        "environment": [],
+                        "mountPoints": [],
+                        "volumesFrom": [],
+                        "logConfiguration": {},
+                    }
+                ],
+            }
+        }
+
+        self.aws_ecs.describe_task_definition = MagicMock(
+            return_value=test_definition__no_log_response
+        )
+
+        # Act
+        log_group_name = self.ecs.extract_log_group_name(
+            container_definition_id=self.TEST_CONTAINER_ID
+        )
+
+        # Assert
+        self.assertIsNone(log_group_name, "log group is None")
+        self.aws_ecs.describe_task_definition.assert_called()

--- a/pce/mapper/aws.py
+++ b/pce/mapper/aws.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from pce.entity.iam_role import (
     IAMRole,
@@ -21,3 +21,16 @@ def map_attachedrolepolicies_to_rolepolicies(
     attached_role_policies: Dict[PolicyName, PolicyContents],
 ) -> Optional[IAMRole]:
     return IAMRole(role_id, attached_role_policies) if attached_role_policies else None
+
+
+def map_ecstaskdefinition_to_awslogsgroupname(
+    task_definition: Dict[str, Any],
+) -> Optional[str]:
+    try:
+        container_definition = task_definition["containerDefinitions"][0]
+        log_configuration = container_definition["logConfiguration"]
+        log_group_name = log_configuration["options"]["awslogs-group"]
+        return log_group_name
+    # Key error indicates the log group does not exist, error will be returned in error message templates
+    except KeyError:
+        return None


### PR DESCRIPTION
Summary: PCEECSGateway is to retrieve aws logs group name from task definition. Since Logs is not part of PCE, need to add this Gateway

Differential Revision: D33864737

