### PR TITLE
refactor message_templates.py file

### DIFF
--- a/pce/validator/message_templates.py
+++ b/pce/validator/message_templates.py
@@ -94,13 +94,3 @@ class ValidationWarningSolutionHintTemplate(Enum):
     MORE_POLICIES_THAN_EXPECTED = (
         "Consider removing additional policies to strengthen security."
     )
-
-
-class ValidationStepNames(Enum):
-    CIDR = "CIDR"
-    VPC_PEERING = "VPC peering"
-    FIREWALL = "Firewall"
-    ROUTE_TABLE = "Route table"
-    SUBNETS = "Subnets"
-    CLUSTER_DEFINITION = "Cluster definition"
-    ROLE = "IAM roles"

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -26,7 +26,6 @@ from pce.validator.message_templates import (
     ValidationErrorSolutionHintTemplate,
     ValidationWarningDescriptionTemplate,
     ValidationWarningSolutionHintTemplate,
-    ValidationStepNames,
 )
 from pce.validator.pce_standard_constants import (
     CONTAINER_CPU,
@@ -36,6 +35,9 @@ from pce.validator.pce_standard_constants import (
     FIREWALL_RULE_INITIAL_PORT,
     IGW_ROUTE_DESTINATION_CIDR_BLOCK,
     TASK_POLICY,
+)
+from pce.validator.validator_step_names import (
+    ValidationStepNames,
 )
 
 

--- a/pce/validator/validator_step_names.py
+++ b/pce/validator/validator_step_names.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# patternlint-disable f-string-may-be-missing-leading-f
+from enum import Enum
+
+
+class ValidationStepNames(Enum):
+    CIDR = "CIDR"
+    VPC_PEERING = "VPC peering"
+    FIREWALL = "Firewall"
+    ROUTE_TABLE = "Route table"
+    SUBNETS = "Subnets"
+    CLUSTER_DEFINITION = "Cluster definition"
+    ROLE = "IAM roles"


### PR DESCRIPTION
Summary: To prepare error handling framework in PCE validator, also for BE purposes, decouple Validator_step_names enum(non-error related message) from PCE validator message templates.

Differential Revision: D33971972

