### PR TITLE
Add comments in error message templates set up which scenarios should raise error message

### DIFF
--- a/pce/validator/error_message_templates.py
+++ b/pce/validator/error_message_templates.py
@@ -19,6 +19,9 @@ from pce.validator.pce_standard_constants import (
     IGW_ROUTE_DESTINATION_CIDR_BLOCK,
 )
 
+# scenarios should raise error message are the ones will block advertiser run study
+# new error message should follow above standard
+
 
 class ValidationErrorDescriptionTemplate(Enum):
     UNKNOWN = "Unknown error"

--- a/pce/validator/error_message_templates.py
+++ b/pce/validator/error_message_templates.py
@@ -70,27 +70,3 @@ class ValidationErrorSolutionHintTemplate(Enum):
     ROLE_POLICIES_NOT_FOUND = (
         "Make sure there are policies attached to {role_names} in the pce {pce_id}."
     )
-
-
-class ValidationWarningDescriptionTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = "Still setting up peering."
-    FIREWALL_CIDR_EXCEED_EXPECTED_RANGE = f"Ingress cidr {{fr_vpc_id}}:{{fri_cidr}}:{{fri_from_port}}-{{fri_to_port}} exceeds the expected port range {FIREWALL_RULE_INITIAL_PORT}-{FIREWALL_RULE_FINAL_PORT}"
-    FIREWALL_FLAGGED_RULESETS = (
-        "These issues are not fatal but are worth noticing: {warning_reasons}"
-    )
-    CLUSTER_DEFINITION_FLAGGED_VALUE = (
-        "{resource_name} value '{value}' is not expected, should be '{expected_value}'."
-    )
-    CLUSTER_DEFINITION_FLAGGED_VALUES = (
-        "Container has outlier values which are non-fatal: {warning_reasons}"
-    )
-    MORE_POLICIES_THAN_EXPECTED = (
-        "Policies {policy_names} attached to {role_id} are not expected."
-    )
-
-
-class ValidationWarningSolutionHintTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = "Please try again in a moment."
-    MORE_POLICIES_THAN_EXPECTED = (
-        "Consider removing additional policies to strengthen security."
-    )

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -21,11 +21,9 @@ from fbpcp.entity.vpc_peering import VpcPeeringState
 from fbpcp.service.pce_aws import PCE_ID_KEY
 from pce.gateway.ec2 import PCEEC2Gateway
 from pce.gateway.iam import PCEIAMGateway
-from pce.validator.message_templates import (
+from pce.validator.error_message_templates import (
     ValidationErrorDescriptionTemplate,
     ValidationErrorSolutionHintTemplate,
-    ValidationWarningDescriptionTemplate,
-    ValidationWarningSolutionHintTemplate,
 )
 from pce.validator.pce_standard_constants import (
     CONTAINER_CPU,
@@ -38,6 +36,10 @@ from pce.validator.pce_standard_constants import (
 )
 from pce.validator.validator_step_names import (
     ValidationStepNames,
+)
+from pce.validator.warning_message_templates import (
+    ValidationWarningDescriptionTemplate,
+    ValidationWarningSolutionHintTemplate,
 )
 
 

--- a/pce/validator/warning_message_templates.py
+++ b/pce/validator/warning_message_templates.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# patternlint-disable f-string-may-be-missing-leading-f
+
+from enum import Enum
+
+from pce.validator.pce_standard_constants import (
+    FIREWALL_RULE_FINAL_PORT,
+    FIREWALL_RULE_INITIAL_PORT,
+)
+
+
+class ValidationWarningDescriptionTemplate(Enum):
+    VPC_PEERING_PEERING_NOT_READY = "Still setting up peering."
+    FIREWALL_CIDR_EXCEED_EXPECTED_RANGE = f"Ingress cidr {{fr_vpc_id}}:{{fri_cidr}}:{{fri_from_port}}-{{fri_to_port}} exceeds the expected port range {FIREWALL_RULE_INITIAL_PORT}-{FIREWALL_RULE_FINAL_PORT}"
+    FIREWALL_FLAGGED_RULESETS = (
+        "These issues are not fatal but are worth noticing: {warning_reasons}"
+    )
+    CLUSTER_DEFINITION_FLAGGED_VALUE = (
+        "{resource_name} value '{value}' is not expected, should be '{expected_value}'."
+    )
+    CLUSTER_DEFINITION_FLAGGED_VALUES = (
+        "Container has outlier values which are non-fatal: {warning_reasons}"
+    )
+    MORE_POLICIES_THAN_EXPECTED = (
+        "Policies {policy_names} attached to {role_id} are not expected."
+    )
+
+
+class ValidationWarningSolutionHintTemplate(Enum):
+    VPC_PEERING_PEERING_NOT_READY = "Please try again in a moment."
+    MORE_POLICIES_THAN_EXPECTED = (
+        "Consider removing additional policies to strengthen security."
+    )


### PR DESCRIPTION
Summary: Add comments in error message templates set a standard for scenarios should raise error message

Differential Revision: D33989746

