### PR TITLE
Return non zero exit code upon ERROR level validation result

### DIFF
--- a/pce/validator/tests/validator_tests.py
+++ b/pce/validator/tests/validator_tests.py
@@ -812,3 +812,19 @@ class TestValidator(TestCase):
                 ValidationWarningSolutionHintTemplate.MORE_POLICIES_THAN_EXPECTED.value,
             ),
         )
+
+
+class TestValidationSuite(TestCase):
+    def test_contains_error_result(self) -> None:
+        results = [
+            ValidationResult(ValidationResultCode.WARNING),
+            ValidationResult(ValidationResultCode.ERROR),
+        ]
+        self.assertTrue(ValidationSuite.contains_error_result(results))
+
+    def test_contains_error_result_warnings_only(self) -> None:
+        results = [
+            ValidationResult(ValidationResultCode.WARNING),
+            ValidationResult(ValidationResultCode.WARNING),
+        ]
+        self.assertFalse(ValidationSuite.contains_error_result(results))

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -432,6 +432,16 @@ class ValidationSuite:
             ]
         )
 
+    @classmethod
+    def contains_error_result(cls, results: List[ValidationResult]) -> bool:
+        return any(
+            [
+                result
+                for result in results
+                if result.validation_result_code == ValidationResultCode.ERROR
+            ]
+        )
+
     def validate_roles(self, pce: PCE) -> ValidationResult:
         """
         Ensure that the container task execution role has the proper policy (`TASK_POLICY`) among those attached to it.

--- a/pce/validator/validator.py
+++ b/pce/validator/validator.py
@@ -18,10 +18,13 @@ Options:
 
 
 import logging
+import sys
 
 from docopt import docopt
 from fbpcp.service.pce_aws import AWSPCEService
-from pce.validator.validation_suite import ValidationSuite
+from pce.validator.validation_suite import (
+    ValidationSuite,
+)
 from schema import Schema, Optional, Or
 
 
@@ -37,6 +40,8 @@ def validate_pce(region: str, key_id: str, key_data: str, pce_id: str) -> None:
         logging.error(
             f"Validation failed for PCE {pce_id}:\n{ValidationSuite.summarize_errors(failed_results)}"
         )
+        if ValidationSuite.contains_error_result(failed_results):
+            sys.exit(1)
     else:
         print("Your PCE environments are set up correctly.")
 


### PR DESCRIPTION
Summary:
Add support for returning non zero exit code when validation results contain atleast one ERROR level result. Currently, the program sets an exitcode of 0 (success) even if the validation resulted in an error.

This will help callsites learn about the overall success/failure of the validator from the exitcode, instead of parsing stdout/stderr for result text.

Note: Errors in the execution of the validation code (eg uncaught exceptions in validation code) will continue to set a non-zero exitcode (no changes in behavior by this diff)

Differential Revision: D34022749

