### PR TITLE
Fix typo in the D34085534

### DIFF
--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -216,11 +216,11 @@ class ECSGateway(AWSGateway, MetricsGetter):
     @error_handler
     def list_task_definitions(self, limit: int = 1000) -> List[str]:
         task_definitions = []
-        next_token = None
+        next_token = ""
 
         while len(task_definitions) < limit:
             task_definition_response = self.client.list_task_definitions(
-                next_token=next_token,
+                nextToken=next_token,
             )
             task_definitions.extend(task_definition_response["taskDefinitionArns"])
             next_token = task_definition_response.get("nextToken")

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -478,7 +478,7 @@ class TestECSGateway(unittest.TestCase):
         )
         tasks = self.gw.list_task_definitions()
         expected_tasks = [self.TEST_TASK_DEFINITION_ARN, self.TEST_TASK_DEFINITION_ARN]
-        expected_calls = [call(next_token=None)]
+        expected_calls = [call(nextToken="")]
         self.assertEqual(tasks, expected_tasks)
         self.gw.client.list_task_definitions.assert_has_calls(expected_calls)
         self.gw.client.list_task_definitions.assert_called_once
@@ -510,9 +510,9 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_TASK_DEFINITION_ARN,
         ]
         expected_calls = [
-            call(next_token=None),
-            call(next_token="token1"),
-            call(next_token="token2"),
+            call(nextToken=""),
+            call(nextToken="token1"),
+            call(nextToken="token2"),
         ]
         self.assertEqual(tasks, expected_tasks)
         self.gw.client.list_task_definitions.assert_has_calls(expected_calls)
@@ -539,7 +539,7 @@ class TestECSGateway(unittest.TestCase):
         )
         tasks = self.gw.list_task_definitions(limit=2)
         expected_tasks = [self.TEST_TASK_DEFINITION_ARN, self.TEST_TASK_DEFINITION_ARN]
-        expected_calls = [call(next_token=None), call(next_token="token1")]
+        expected_calls = [call(nextToken=""), call(nextToken="token1")]
         self.assertEqual(tasks, expected_tasks)
         self.gw.client.list_task_definitions.assert_has_calls(expected_calls)
 
@@ -568,6 +568,6 @@ class TestECSGateway(unittest.TestCase):
         )
         tasks = self.gw.list_task_definitions(limit=2)
         expected_tasks = [self.TEST_TASK_DEFINITION_ARN, self.TEST_TASK_DEFINITION_ARN]
-        expected_calls = [call(next_token=None), call(next_token="token1")]
+        expected_calls = [call(nextToken=""), call(nextToken="token1")]
         self.assertEqual(tasks, expected_tasks)
         self.gw.client.list_task_definitions.assert_has_calls(expected_calls)


### PR DESCRIPTION
Summary:
As title. Here is a quick fix that we use the correct parameter name for nextToken.

This diff also change the default value of nextToken to an empty string. The Boto3 api don't take None as the nextToken.

Differential Revision: D34130324

