### PR TITLE
Improve VPC Peering validation messaging

### DIFF
--- a/pce/validator/error_message_templates.py
+++ b/pce/validator/error_message_templates.py
@@ -33,7 +33,9 @@ class ValidationErrorDescriptionTemplate(Enum):
     FIREWALL_CIDR_NOT_OVERLAPS_VPC = "VPC peering for VPC {peer_target_id} doesn't have an inbound rule to allow traffic to {vpc_id}:{vpc_cidr}."
     FIREWALL_CIDR_CANT_CONTAIN_EXPECTED_RANGE = f"Ingress cidr {{fr_vpc_id}}:{{fri_cidr}}:{{fri_from_port}}-{{fri_to_port}} can't contain the expected port range {FIREWALL_RULE_INITIAL_PORT}-{FIREWALL_RULE_FINAL_PORT}"
     FIREWALL_INVALID_RULESETS = "Invalid firewall rulesets: {error_reasons}"
-    ROUTE_TABLE_VPC_PEERING_MISSING = "No valid VPC peering found in route table."
+    ROUTE_TABLE_VPC_PEERING_MISSING = (
+        "No Active route for VPC Peering Connection found in the route table."
+    )
     ROUTE_TABLE_IGW_MISSING = "Internet Gateway route missing in route table."
     ROUTE_TABLE_IGW_INACTIVE = "Internet Gateway route is not Active."
     CLUSTER_DEFINITION_NOT_SET = "No container definition."
@@ -55,7 +57,11 @@ class ValidationErrorSolutionHintTemplate(Enum):
     FIREWALL_INVALID_RULESETS = (
         "Set correct CIDR and port ranges for the offending firewall rules."
     )
-    ROUTE_TABLE_VPC_PEERING_MISSING = "Define a VPC connection in the route table."
+    ROUTE_TABLE_VPC_PEERING_MISSING = (
+        "Ensure that a route for VPC Peering Connection is present and Active in the route table. "
+        "If present but not Active, check if the VPC Peering Connection request is pending "
+        "acceptance by the owner of the Acceptor VPC."
+    )
     ROUTE_TABLE_IGW_MISSING = (
         f"Ensure that a route for destination {IGW_ROUTE_DESTINATION_CIDR_BLOCK} "
         "to an Internet Gateway target is added to the route table."

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -274,7 +274,8 @@ class ValidationSuite:
 
     def validate_route_table(self, pce: PCE) -> ValidationResult:
         """
-        Make sure there is an entry in the route table for the VPC peer and that it is active
+        Make sure routing table has all the required routes in active state
+        This includes routes for a Peering Connection and an Internet Gateway
         """
         vpc = pce.pce_network.vpc
         if not vpc:

--- a/pce/validator/warning_message_templates.py
+++ b/pce/validator/warning_message_templates.py
@@ -21,7 +21,9 @@ from pce.validator.pce_standard_constants import (
 
 
 class ValidationWarningDescriptionTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = "Still setting up peering."
+    VPC_PEERING_PEERING_NOT_READY = (
+        "VPC Peering Connection request is pending acceptance."
+    )
     FIREWALL_CIDR_EXCEED_EXPECTED_RANGE = f"Ingress cidr {{fr_vpc_id}}:{{fri_cidr}}:{{fri_from_port}}-{{fri_to_port}} exceeds the expected port range {FIREWALL_RULE_INITIAL_PORT}-{FIREWALL_RULE_FINAL_PORT}"
     FIREWALL_FLAGGED_RULESETS = (
         "These issues are not fatal but are worth noticing: {warning_reasons}"
@@ -42,7 +44,9 @@ class ValidationWarningDescriptionTemplate(Enum):
 
 
 class ValidationWarningSolutionHintTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = "Please try again in a moment."
+    VPC_PEERING_PEERING_NOT_READY = (
+        "Please work with Acceptor VPC owner to accept peering request."
+    )
     MORE_POLICIES_THAN_EXPECTED = (
         "Consider removing additional policies to strengthen security."
     )


### PR DESCRIPTION
Summary:
For a VPC peering connection to be correctly setup in a PCE, there are two distinct components that need to be correctly setup, hence two distinct validations exist. The two components are:

1. VPC peering connection resource (request created by automation but currently needs manual intervention to be "approved")
2. A route in the VPC's routing table to target all traffic destined to the peered VPC

This change makes the messaging from these two validations more clear for a PCE that has the VPC Peering Connection request created but NOT ACCEPTED yet (manual action pending).

The diff in messaging before and after this change can be seen below:

```
 --- before.txt  2022-02-11 16:39:02.719821246 -0800
+++ after.txt   2022-02-11 16:39:32.151237291 -0800
@@ -4,6 +4,6 @@
 Validating PCE...  [####################################]  100%
 ERROR:root:Validation failed for PCE test-peering-prtnr:
 ValidationResultCode.WARNING:
-        Still setting up peering. Please try again in a moment.
+        VPC Peering Connection request is pending acceptance. Please work with Acceptor VPC owner to accept peering request.
 ValidationResultCode.ERROR:
-        No valid VPC peering found in route table. Define a VPC connection in the route table.
+        No Active route for VPC Peering Connection found in the route table. Ensure that a route for VPC Peering Connection is present and Active in the route table. If present but not Active, check if the VPC Peering Connection request is pending acceptance by the owner of the Acceptor VPC.

```

Reviewed By: zehuali

Differential Revision: D34190845

