### PR TITLE
Print Acceptor VPC ID in VPC Peering pending warning message

### DIFF
--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -144,7 +144,9 @@ class ValidationSuite:
                 VpcPeeringState.PENDING_ACCEPTANCE: ValidationResult(
                     ValidationResultCode.WARNING,
                     ValidationWarningDescriptionTemplate.VPC_PEERING_PEERING_NOT_READY.value,
-                    ValidationWarningSolutionHintTemplate.VPC_PEERING_PEERING_NOT_READY.value,
+                    ValidationWarningSolutionHintTemplate.VPC_PEERING_PEERING_NOT_READY.value.format(
+                        accepter_vpc_id=vpc_peering.accepter_vpc_id
+                    ),
                 ),
             },
         )

--- a/pce/validator/warning_message_templates.py
+++ b/pce/validator/warning_message_templates.py
@@ -44,9 +44,7 @@ class ValidationWarningDescriptionTemplate(Enum):
 
 
 class ValidationWarningSolutionHintTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = (
-        "Please work with Acceptor VPC owner to accept peering request."
-    )
+    VPC_PEERING_PEERING_NOT_READY = "Please work with owner of Acceptor VPC (VPC ID: {accepter_vpc_id}) to accept peering request."
     MORE_POLICIES_THAN_EXPECTED = (
         "Consider removing additional policies to strengthen security."
     )


### PR DESCRIPTION
Summary:
Small improvement to make call to action clearer in warning message for when a PCE has a pending VPC peering request (everytime just after PCE creation via automation, the action to "Approve" the VPC peering request requires manual intervention presently).

By annotating the VPC ID in the warning message, it makes it easier for Acceptor to identify which VPC is being requested to be peered with.

```
ValidationResultCode.WARNING: VPC Peering Connection request is pending acceptance. Please work with owner of Acceptor VPC (VPC ID: vpc-008ced81cf3ef9794) to accept peering request.
```

Differential Revision: D34442239

