### PR TITLE
Print VPC Peering state in error message when peering not in acceptable state

### DIFF
--- a/pce/validator/error_message_templates.py
+++ b/pce/validator/error_message_templates.py
@@ -26,6 +26,9 @@ from pce.validator.pce_standard_constants import (
 class ValidationErrorDescriptionTemplate(Enum):
     UNKNOWN = "Unknown error"
     VPC_PEERING_NO_VPC_PEERING = "No VPC peering set."
+    # Unacceptable states include VpcPeeringState.REJECTED and VpcPeeringState.NOT_READY
+    # The latter maps any other state not explicitly listed in the VpcPeeringState Enum
+    VPC_PEERING_UNACCEPTABLE_STATE = "VPC Peering is in unacceptable state: {status}."
     VPC_PEERING_NO_VPC = "VPC not found."
     VPC_PEERING_NO_VPC_CIDR = "No VPC CIDR set."
     VPC_PEERING_NO_ROUTE_TABLE = "No route table set."

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -137,7 +137,9 @@ class ValidationSuite:
         state_results = defaultdict(
             lambda: ValidationResult(
                 ValidationResultCode.ERROR,
-                ValidationErrorDescriptionTemplate.UNKNOWN.value,
+                ValidationErrorDescriptionTemplate.VPC_PEERING_UNACCEPTABLE_STATE.value.format(
+                    status=vpc_peering.status
+                ),
             ),
             {
                 VpcPeeringState.ACTIVE: ValidationResult(ValidationResultCode.SUCCESS),

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -144,7 +144,9 @@ class ValidationSuite:
                 VpcPeeringState.PENDING_ACCEPTANCE: ValidationResult(
                     ValidationResultCode.WARNING,
                     ValidationWarningDescriptionTemplate.VPC_PEERING_PEERING_NOT_READY.value,
-                    ValidationWarningSolutionHintTemplate.VPC_PEERING_PEERING_NOT_READY.value,
+                    ValidationWarningSolutionHintTemplate.VPC_PEERING_PEERING_NOT_READY.value.format(
+                        accepter_vpc_id=vpc_peering.accepter_vpc_id
+                    ),
                 ),
             },
         )

--- a/pce/validator/warning_message_templates.py
+++ b/pce/validator/warning_message_templates.py
@@ -44,9 +44,7 @@ class ValidationWarningDescriptionTemplate(Enum):
 
 
 class ValidationWarningSolutionHintTemplate(Enum):
-    VPC_PEERING_PEERING_NOT_READY = (
-        "Please work with Acceptor VPC owner to accept peering request."
-    )
+    VPC_PEERING_PEERING_NOT_READY = "Please work with owner of Acceptor VPC (VPC ID: {accepter_vpc_id}) to accept peering request."
     MORE_POLICIES_THAN_EXPECTED = (
         "Consider removing additional policies to strengthen security."
     )


### PR DESCRIPTION
Summary: Improve error messaging when VPC peering is not in the ACTIVE or PENDING_ACCEPTANCE states by printing the state the peering is in.

Differential Revision: D34442639

