### PR TITLE
Refactor the instance update logic in MPC service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,10 @@ Release PCE validator and update onedocker dependencies
 * Fixes bug introduced in 0.2.4 (And 0.2.4 was deleted from pypi to prevent further usage)
 * The fix is to use the correct parameter name nextToken in list_task_definitions - PR # 252
 * (From 0.2.3 -> 0.2.4) PCE Validator CLI Change: Implement returning non zero exit code for error results
+
+## 0.2.5 -> 0.2.6
+### Types of changes
+* Bug fix (non-breaking change which fixes an issue)
+
+### Description of changes
+* Updated the instance updating logic in MPC service

--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -122,7 +122,7 @@ class ECSGateway(AWSGateway, MetricsGetter):
             ] = map_ecstask_to_containerinstance(resp_task_dict)
 
         for failure in response["failures"]:
-            self.logger.error(
+            self.logger.warning(
                 f"ECSGateway failed to describe a task {failure['arn']}, reason: {failure['reason']}"
             )
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.5",
+    version="0.2.6",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -243,3 +243,36 @@ class TestMPCService(unittest.TestCase):
         self.mpc_service.instance_repository.update.assert_called_with(
             expected_mpc_instance
         )
+
+    def test_get_updated_instance(self):
+        # Arrange
+        queried_container = ContainerInstance(
+            TEST_INSTANCE_ID,  # noqa
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.COMPLETED,
+        )
+        existing_container_started = ContainerInstance(
+            TEST_INSTANCE_ID,
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.STARTED,
+        )
+        existing_container_completed = ContainerInstance(
+            TEST_INSTANCE_ID,
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.COMPLETED,
+        )
+
+        # Act and Assert
+        self.assertEqual(
+            queried_container,
+            self.mpc_service._get_updated_container(
+                queried_container, existing_container_started
+            ),
+        )
+        self.assertIsNone(
+            self.mpc_service._get_updated_container(None, existing_container_started)
+        )
+        self.assertEqual(
+            existing_container_completed,
+            self.mpc_service._get_updated_container(None, existing_container_completed),
+        )


### PR DESCRIPTION
Summary:
When mpc service queries the status of running containers, it read the container instance from its repository and using the container ids as the input to do the query.

It is very likely that part of the containers are cleaned up by AWS (1 hr ETA after stop), while others are still running, which makes the number of containerInstances inconsistent. We will need to refactor the logic of update MPC repository. Please see ``_get_updated_container`` for new logic

The new query logic:

1. If ECS returns an instance, return the instance to callers
2. If ECS could not find an instance and the status of existing instance is not stopped, return None to callers
3. If ECS cound not find an instance and the status of existing instance is stopped, return the existing instance to callers.

Differential Revision: D34410047

