### PR TITLE
Handle different publisher VPC CIDR

### DIFF
--- a/pce/README.md
+++ b/pce/README.md
@@ -12,11 +12,21 @@ PCE Validator is to verify above PCE components are set up correctly. It will ch
 
 Currently, PCE Validator only supports AWS(Amazon Web Services). You should tag all your resource for the PCE with {"pce:pce-id": "<your-pce-id>"} in order to run validator.
 
+## MPC Roles
+MPC(Multi Party Computation) Roles includes publisher and partner.  If you donot pass in a role, it will use partner role by default. All advertisers need to use partner role, publisher role is for advertising provider.
+
+
 ## Installing PCE
 You need to install through fbpcp [README](https://github.com/facebookresearch/fbpcp/blob/main/README.md).
 
 ## PCE Validator Usage
- python3.8 -m pce.validator --region=<region> --key-id=<key_id> --key-data=<key_data> --pce-id=<pce_id>
+ python3.8 -m pce.validator --region=<region> --key-id=<key_id> --key-data=<key_data> --pce-id=<pce_id> --role=<role>
 
-Example: for resources tagged with {"pce:pce-id": "test-pce-tag-value"}
+Example1: for resources tagged with {"pce:pce-id": "test-pce-tag-value"}
  python3.8 -m pce.validator --region=us-west-2 --key-id=AWS_ACCESS_KEY_ID --key-data=AWS_SECRET_ACCESS_KEY --pce-id="test-pce-tag-value"
+
+Example2: if your host has AWS environment variables setup, you can remove --key-id= and --key-data
+ python3.8 -m pce.validator --region=us-west-2 --pce-id="test-pce-tag-value"
+
+Example3: you can optionally pass in the role, the output will stay the same
+ python3.8 -m pce.validator --region=us-west-2 --pce-id="test-pce-tag-value" --role partner

--- a/pce/entity/mpc_roles.py
+++ b/pce/entity/mpc_roles.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class MPCRoles(Enum):
+    PUBLISHER = "PUBLISHER"
+    PARTNER = "PARTNER"

--- a/pce/validator/tests/validator_tests.py
+++ b/pce/validator/tests/validator_tests.py
@@ -26,6 +26,7 @@ from pce.entity.iam_role import (
     PolicyContents,
 )
 from pce.entity.log_group_aws import LogGroup
+from pce.entity.mpc_roles import MPCRoles
 from pce.validator.pce_standard_constants import (
     AvailabilityZone,
     CONTAINER_CPU,
@@ -37,6 +38,7 @@ from pce.validator.pce_standard_constants import (
     IGW_ROUTE_TARGET_PREFIX,
     TASK_POLICY,
     DEFAULT_PARTNER_VPC_CIDR,
+    DEFAULT_VPC_CIDR,
 )
 from pce.validator.validation_suite import (
     ValidationResult,
@@ -215,6 +217,22 @@ class TestValidator(TestCase):
                 ),
                 None,
             )
+
+    def test_validate_partner_cidr(self) -> None:
+        pce = MagicMock()
+        pce.pce_network.vpc.cidr = DEFAULT_PARTNER_VPC_CIDR
+        self.validator.role = MPCRoles.PARTNER
+        expected_result = ValidationResult(ValidationResultCode.SUCCESS)
+        actual_result = self.validator.validate_private_cidr(pce)
+        self.assertEquals(expected_result, actual_result)
+
+    def test_validate_publisher_cidr(self) -> None:
+        pce = MagicMock()
+        pce.pce_network.vpc.cidr = DEFAULT_VPC_CIDR
+        self.validator.role = MPCRoles.PUBLISHER
+        expected_result = ValidationResult(ValidationResultCode.SUCCESS)
+        actual_result = self.validator.validate_private_cidr(pce)
+        self.assertEquals(expected_result, actual_result)
 
     def _test_validate_firewall(
         self,


### PR DESCRIPTION
Summary:
PCE Publisher and Partner mostly shares the same setup, as such the validation functions can be ran on both sides.  However, one difference need to address is VPC CIDR.  Partner VPC CIDR is always 10.1.0.0/16, while publisher is 10.0.0.0/16. This is hardcoded and during validation, I want to differiecieate publisher and partner by introducing a new argument: role.

To maintain the same behavior on partner end, if role is not specified, it will use partner by default.

Differential Revision: D34776172

