### PR TITLE
Include AWS request-id and other response metadata in PCP's error message

### DIFF
--- a/fbpcp/error/mapper/aws.py
+++ b/fbpcp/error/mapper/aws.py
@@ -15,7 +15,8 @@ from fbpcp.error.pcp import ThrottlingError
 # reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
 def map_aws_error(error: ClientError) -> PcpError:
     code = error.response["Error"]["Code"]
-    message = str(error)
+    response_metadata = error.response["ResponseMetadata"]
+    message = f"{error}\n\n Details: {response_metadata}\n"
 
     if code == "InvalidParameterException":
         return InvalidParameterError(message)

--- a/tests/decorator/test_error_handler.py
+++ b/tests/decorator/test_error_handler.py
@@ -30,6 +30,10 @@ class TestErrorHandler(unittest.TestCase):
                         "Code": "ThrottlingException",
                         "Message": "test",
                     },
+                    "ResponseMetadata": {
+                        "RequestId": "test_id",
+                        "HTTPStatusCode": 400,
+                    },
                 },
                 "test",
             )

--- a/tests/error/mapper/test_aws.py
+++ b/tests/error/mapper/test_aws.py
@@ -14,11 +14,16 @@ from fbpcp.error.pcp import ThrottlingError
 
 class TestMapAwsError(unittest.TestCase):
     def test_pcs_error(self):
+        request_id = "76f3e69f-0d46-436f-803a-5e88956b7308"
         err = ClientError(
             {
                 "Error": {
                     "Code": "Exception",
                     "Message": "test",
+                },
+                "ResponseMetadata": {
+                    "RequestId": request_id,
+                    "HTTPStatusCode": 400,
                 },
             },
             "test",
@@ -26,13 +31,19 @@ class TestMapAwsError(unittest.TestCase):
         err = map_aws_error(err)
 
         self.assertIsInstance(err, PcpError)
+        self.assertIn(request_id, str(err))
 
     def test_throttling_error(self):
+        request_id = "3e65a825-6a43-4261-b8a4-953972aa7065"
         err = ClientError(
             {
                 "Error": {
                     "Code": "ThrottlingException",
                     "Message": "test",
+                },
+                "ResponseMetadata": {
+                    "RequestId": request_id,
+                    "HTTPStatusCode": 400,
                 },
             },
             "test",
@@ -40,3 +51,4 @@ class TestMapAwsError(unittest.TestCase):
         err = map_aws_error(err)
 
         self.assertIsInstance(err, ThrottlingError)
+        self.assertIn(request_id, str(err))

--- a/tests/gateway/test_s3.py
+++ b/tests/gateway/test_s3.py
@@ -104,7 +104,10 @@ class TestS3Gateway(unittest.TestCase):
         gw.client = BotoClient()
         error_code = "403"
         error_msg = "Permission denied"
-        error_response = {"Error": {"Code": error_code, "Message": error_msg}}
+        error_response = {
+            "Error": {"Code": error_code, "Message": error_msg},
+            "ResponseMetadata": {},
+        }
         gw.client.head_object = MagicMock(
             side_effect=ClientError(error_response, TEST_S3_OPERATION)
         )


### PR DESCRIPTION
Summary:
According to AWS support: "whenever you need to contact AWS Support due to encountering errors or unexpected behavior in Amazon S3, you will need to get the request IDs associated with the failed action."

To expedite the troubleshooting process, we should include request IDs and other response metadata (I verified that the payload does not contain sensitive info).

https://docs.aws.amazon.com/AmazonS3/latest/userguide/get-request-ids.html

Reviewed By: zhuang-93

Differential Revision: D34801484

