### PR TITLE
Handle Publisher VPC peering connection

### DIFF
--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -8,7 +8,9 @@
 from typing import List, Optional, Dict, Any
 
 import boto3
+from fbpcp.entity.vpc_peering import VpcPeering
 from fbpcp.gateway.aws import AWSGateway
+from fbpcp.mapper.aws import map_ec2vpcpeering_to_vpcpeering
 
 
 class PCEEC2Gateway(AWSGateway):
@@ -31,3 +33,19 @@ class PCEEC2Gateway(AWSGateway):
         response = self.client.describe_availability_zones()
 
         return [aws_az["ZoneName"] for aws_az in response["AvailabilityZones"]]
+
+    def describe_vpc_peering_connections_with_accepter_vpc_id(
+        self,
+        vpc_id: str,
+    ) -> Optional[VpcPeering]:
+        filters = [
+            {"Name": "accepter-vpc-info.vpc-id", "Values": [vpc_id]},
+        ]
+        response = self.client.describe_vpc_peering_connections(Filters=filters)
+        return (
+            map_ec2vpcpeering_to_vpcpeering(
+                response["VpcPeeringConnections"][0], vpc_id
+            )
+            if response["VpcPeeringConnections"]
+            else None
+        )

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -10,19 +10,25 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from fbpcp.entity.vpc_peering import VpcPeering, VpcPeeringRole, VpcPeeringState
 from pce.gateway.ec2 import PCEEC2Gateway
-
-REGION = "us-west-2"
 
 
 class TestPCEEC2Gateway(TestCase):
+    REGION = "us-west-2"
+    TEST_AWS_ACCOUNT_ID = "123456789012"
+    TEST_ACCEPTER_VPC_ID = "vpc-12345"
+    TEST_REQUESTER_VPC_ID = "vpc-56789"
+    TEST_VPC_PEERING_ID = "pcx-77889900"
+
     def setUp(self) -> None:
         self.aws_ec2 = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_ec2
-            self.ec2 = PCEEC2Gateway(REGION)
+            self.ec2 = PCEEC2Gateway(self.REGION)
 
     def test_describe_availability_zones(self) -> None:
+        # Arrange
         client_return_response = {
             "AvailabilityZones": [
                 {
@@ -54,8 +60,72 @@ class TestPCEEC2Gateway(TestCase):
             "foo_3_zone",
             "foo_4_zone",
         ]
-
+        # Act
         availability_zones = self.ec2.describe_availability_zones()
-        self.assertEqual(expected_availability_zones, availability_zones)
 
+        # Assert
+        self.assertEqual(expected_availability_zones, availability_zones)
         self.aws_ec2.describe_availability_zones.assert_called()
+
+    def test_describe_vpc_peering_connections_with_accepter_vpc_id(self) -> None:
+        # Arrange
+        client_return_response = {
+            "VpcPeeringConnections": [
+                {
+                    "AccepterVpcInfo": {
+                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlockSet": [{"CidrBlock": "10.0.0.0/16"}],
+                        "OwnerId": self.TEST_AWS_ACCOUNT_ID,
+                        "VpcId": self.TEST_ACCEPTER_VPC_ID,
+                        "Region": self.REGION,
+                    },
+                    "RequesterVpcInfo": {
+                        "CidrBlock": "10.1.0.0/16",
+                        "CidrBlockSet": [{"CidrBlock": "10.1.0.0/16"}],
+                        "OwnerId": self.TEST_AWS_ACCOUNT_ID,
+                        "VpcId": self.TEST_REQUESTER_VPC_ID,
+                        "Region": self.REGION,
+                    },
+                    "Status": {"Code": "active", "Message": "Active"},
+                    "VpcPeeringConnectionId": self.TEST_VPC_PEERING_ID,
+                }
+            ],
+        }
+        self.aws_ec2.describe_vpc_peering_connections = MagicMock(
+            return_value=client_return_response
+        )
+
+        expected_vpc_peering = VpcPeering(
+            id=self.TEST_VPC_PEERING_ID,
+            status=VpcPeeringState.ACTIVE,
+            role=VpcPeeringRole.ACCEPTER,
+            requester_vpc_id=self.TEST_REQUESTER_VPC_ID,
+            accepter_vpc_id=self.TEST_ACCEPTER_VPC_ID,
+        )
+
+        # Act
+        vpc_peering_connection = (
+            self.ec2.describe_vpc_peering_connections_with_accepter_vpc_id(
+                vpc_id=self.TEST_ACCEPTER_VPC_ID
+            )
+        )
+
+        # Assert
+        self.assertEqual(vpc_peering_connection, expected_vpc_peering)
+        self.aws_ec2.describe_vpc_peering_connections.assert_called
+
+    def test_describe_vpc_peering_connections_with_no_accepter_vpc_id(self) -> None:
+        # Arrange
+        client_return_response = {"VpcPeeringConnections": []}
+        self.aws_ec2.describe_vpc_peering_connections = MagicMock(
+            return_value=client_return_response
+        )
+
+        # Act
+        vpc_peering_connection = (
+            self.ec2.describe_vpc_peering_connections_with_accepter_vpc_id(vpc_id=None)
+        )
+
+        # Assert
+        self.assertIsNone(vpc_peering_connection, "vpc peering connection is None")
+        self.aws_ec2.describe_vpc_peering_connections.assert_called

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -138,7 +138,18 @@ class ValidationSuite:
         )
 
     def validate_vpc_peering(self, pce: PCE) -> ValidationResult:
-        vpc_peering = pce.pce_network.vpc_peering
+        if self.role == MPCRoles.PARTNER:
+            vpc_peering = pce.pce_network.vpc_peering
+        else:
+            vpc = pce.pce_network.vpc
+            vpc_peering = (
+                self.ec2_gateway.describe_vpc_peering_connections_with_accepter_vpc_id(
+                    vpc_id=vpc.vpc_id
+                )
+                if vpc
+                else None
+            )
+
         if not vpc_peering:
             return ValidationResult(
                 ValidationResultCode.ERROR,


### PR DESCRIPTION
Summary:
vpc peering connection is not tagged as pce:pce-id on publisher end at this moment. As such, every time when runnign pce validator on publisher end, it rasies error: No VPC peering set.

In order to fix validator on publisher end, I need to retrieve vpc peering ID based on accepter VPC ID(not using tags)

In the future, once VPC peering id is properly tagged on publisher end, I will switch back to use tags to retrieve vpc peering connection.

Differential Revision: D35035603

