### PR TITLE
Coredump handler for AWS

### DIFF
--- a/onedocker/common/core_dump_handler_aws.py
+++ b/onedocker/common/core_dump_handler_aws.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+import os
+import uuid
+from typing import Optional
+
+from fbpcp.service.storage import StorageService
+from onedocker.common.core_dump_handler import CoreDumpHandler
+
+CORE_DUMP_FILE_PREFIX = "core"
+
+
+class AWSCoreDumpHandler(CoreDumpHandler):
+    def __init__(self, storage_svc: StorageService) -> None:
+        self.storage_svc = storage_svc
+        self.logger: logging.Logger = logging.getLogger("__name__")
+
+    def locate_core_dump_file(self) -> Optional[str]:
+        """Find the absolute path of the generated core dump file
+        AWS: /proc/sys/kernel/core_pattern: core
+        The core dump file will be generated in the current
+        working dir. File name starts with 'core'.
+        """
+        cwd = os.getcwd()
+        file_list = [f for f in os.listdir(cwd) if f.startswith(CORE_DUMP_FILE_PREFIX)]
+
+        if len(file_list) == 0:
+            self.logger.error(f"Core dump file not found in {cwd}!")
+            return None
+
+        # One core file is generated for each run
+        file_path = os.path.join(cwd, file_list[0])
+        self.logger.info(f"Core dump file locates in {file_path}")
+
+        return file_path
+
+    def upload_core_dump_file(self, core_dump_file_path: str, upload_dest: str) -> None:
+        """Upload the core dump file to S3
+        Valid upload_dest for AWS is the S3 bucket e.g. http://test.s3.us-west-2.amazonaws.com/
+        """
+        # uploaded core file named as core.uuid
+        file_suffix = str(uuid.uuid4())
+        s3_dest = f"{upload_dest}core.{file_suffix}"
+        self.storage_svc.copy(core_dump_file_path, s3_dest)
+        self.logger.info(f"Core dump file was uploaded to {s3_dest}")

--- a/onedocker/tests/common/test_core_dump_handler_aws.py
+++ b/onedocker/tests/common/test_core_dump_handler_aws.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+from onedocker.common.core_dump_handler_aws import AWSCoreDumpHandler
+
+
+class TestAWSCoreDumpHandler(unittest.TestCase):
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def setUp(self, MockStorageService):
+        self.aws_core_dump_handler = AWSCoreDumpHandler(MockStorageService)
+
+    @patch("os.getcwd", return_value="/root/onedocker")
+    @patch(
+        "os.listdir",
+        return_value=["a.out", "b.exe", "src", "core.20.2"],
+    )
+    def test_locate_core_dump_file(self, mock_listdir, mock_getcwd):
+        expected_path = "/root/onedocker/core.20.2"
+        test_path = self.aws_core_dump_handler.locate_core_dump_file()
+        self.assertEqual(test_path, expected_path)
+
+    @patch("uuid.uuid4", return_value="5f6ed2dd-7d99-4445-9419-8cc13c4adc6b")
+    def test_upload_core_dump_file(self, mock_uuid):
+        upload_dest = "http://test.s3.us-west-2.amazonaws.com/"
+        core_file_path = "/root/onedocker/core.20.2"
+        expected_s3_dest = f"{upload_dest}core.{mock_uuid.return_value}"
+        self.aws_core_dump_handler.upload_core_dump_file(core_file_path, upload_dest)
+        self.aws_core_dump_handler.storage_svc.copy.assert_called_with(
+            core_file_path, expected_s3_dest
+        )


### PR DESCRIPTION
Summary: Implementation of the coredump handler for AWS. After the uploading user would be able to find the name of the uploaded core file in the log. Next diff will integrate the coredump handler with OneDocker runner.

Differential Revision: D35034768

