### PR TITLE
Adding support for test repository in PCS for MPC games. (#757)

### DIFF
--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -127,10 +127,16 @@ class MPCService:
         server_ips: Optional[List[str]] = None,
         timeout: Optional[int] = None,
         version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> MPCInstance:
         return asyncio.run(
             self.start_instance_async(
-                instance_id, output_files, server_ips, timeout, version
+                instance_id,
+                output_files,
+                server_ips,
+                timeout,
+                version,
+                env_vars,
             )
         )
 
@@ -141,6 +147,7 @@ class MPCService:
         server_ips: Optional[List[str]] = None,
         timeout: Optional[int] = None,
         version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> MPCInstance:
         """To run a distributed MPC game
         Keyword arguments:
@@ -163,6 +170,7 @@ class MPCService:
             server_ips,
             timeout,
             version,
+            env_vars,
         )
 
         if len(instance.containers) != instance.num_workers:
@@ -239,6 +247,7 @@ class MPCService:
         ip_addresses: Optional[List[str]] = None,
         timeout: Optional[int] = None,
         version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> List[ContainerInstance]:
         if game_args is not None and len(game_args) != num_containers:
             raise ValueError(
@@ -268,6 +277,7 @@ class MPCService:
             version=version,
             cmd_args_list=cmd_args_list,
             timeout=timeout,
+            env_vars=env_vars,
         )
 
         self.logger.info(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcs/pull/757

# Context

All the private computation production binaries as stored in a public S3 Repository - one-docker-repository-prod. Due to security concerns as well as not to interfere with with the production code currently run by advertisers, we cannot upload binaries created on unreleased code to this public repo.

This creates a challenge in order to test the binaries with PCS service.
In order to resolve this issue, in this stack I am adding support for running custom binaries through PCS and thus using end to end tests and EP.

For this, I have created a separate private S3 bucket - one-docker-repository-test. We can upload any unreleased code to this buckets as this are private and separate from production route. In this stack of diffs I will be adding support for using one-docker-repository-test through PCS as well as build scripts.

# This Diff
In this diff adding support for one-docker-repository-test in PCS for MPC binaries.

# This Stack
1. Add support for one-docker-repository-test in PCS for MPC binaries.
2. Add support for uploading to one-docker-repository-test in build script.
3. Add support for one-docker-repository-test in PCS for PID binaries.
4. Add option to fbpcs_e2e_runner to use test repository.
5. Add path to EP for custom repository.
6.  (Not a diff but) - Publish documentation/post to detail use of the new functionality, as well as guidelines for developers to use test their custom binaries.

Reviewed By: gorel

Differential Revision: D35096344

