### PR TITLE
Improve the locate_core_dump_file function

### DIFF
--- a/onedocker/common/core_dump_handler_aws.py
+++ b/onedocker/common/core_dump_handler_aws.py
@@ -9,6 +9,7 @@
 import logging
 import os
 import uuid
+from pathlib import Path
 from typing import Optional
 
 from fbpcp.service.storage import StorageService
@@ -37,8 +38,14 @@ class AWSCoreDumpHandler(CoreDumpHandler):
 
         # One core file is generated for each run
         file_path = os.path.join(cwd, file_list[0])
-        self.logger.info(f"Core dump file locates in {file_path}")
 
+        if not Path(file_path).is_file:
+            # If the file path points to a non-file type
+            # return None
+            self.logger.error(f"{file_path} is not a file.")
+            return None
+
+        self.logger.info(f"Core dump file locates in {file_path}")
         return file_path
 
     def upload_core_dump_file(self, core_dump_file_path: str, upload_dest: str) -> None:


### PR DESCRIPTION
Summary: This diff added the check (moved from OneDocker runner) to function `locate_core_dump_file` to make sure the return value is a valid path or None (if doesn't exist).

Differential Revision: D35161370

