### PR TITLE
Add container_definition validation in OneDocker Service

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -109,3 +109,11 @@ class ContainerService(abc.ABC):
             Integer that represent the total pending and running instances count for cluster
         """
         pass
+
+    @abc.abstractmethod
+    def validate_container_definition(self, container_definition: str) -> None:
+        """Validate the format of a specific container definition.
+        Raises:
+            InvalidParameterError: The container definition is not in a valid format.
+        """
+        pass

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -7,10 +7,11 @@
 # pyre-strict
 
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance
-from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import InvalidParameterError, PcpError
 from fbpcp.gateway.ecs import ECSGateway
 from fbpcp.metrics.emitter import MetricsEmitter
 from fbpcp.service.container import ContainerService
@@ -120,3 +121,9 @@ class AWSContainerService(ContainerService):
     def get_current_instances_count(self) -> int:
         cluster = self.ecs_gateway.describe_cluster(self.cluster)
         return cluster.running_tasks + cluster.pending_tasks
+
+    def validate_container_definition(self, container_definition: str) -> None:
+        if not re.fullmatch(r"[\w-]+?:\d+#[\w-]+?", container_definition):
+            raise InvalidParameterError(
+                "Parameter container_definition must be in format <task definition name>:<revision>#<container name>"
+            )

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -49,8 +49,9 @@ class OneDockerService(MetricsGetter):
         """
         if container_svc is None:
             raise ValueError(f"Dependency is missing. container_svc={container_svc}, ")
-
         self.container_svc = container_svc
+        if task_definition:
+            self.container_svc.validate_container_definition(task_definition)
         self.task_definition = task_definition
         self.metrics: Final[Optional[MetricsEmitter]] = metrics
         self.logger: logging.Logger = logging.getLogger(__name__)
@@ -125,6 +126,8 @@ class OneDockerService(MetricsGetter):
         Returns:
             A list of the containers that were successfuly started
         """
+        if task_definition:
+            self.container_svc.validate_container_definition(task_definition)
         if not cmd_args_list:
             raise ValueError("Command Argument List shouldn't be None or Empty")
 


### PR DESCRIPTION
Summary: We want to check if user uses the wrong format of container_definition in OneDocker. The correct format for container_definition should be *<task definition name>:<revision>#<container name>*. This diff adds such validation and provide some informative logs to users.

Reviewed By: zhuang-93

Differential Revision: D35237834

