### PR TITLE
fix container definition validation

### DIFF
--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -123,7 +123,7 @@ class AWSContainerService(ContainerService):
         return cluster.running_tasks + cluster.pending_tasks
 
     def validate_container_definition(self, container_definition: str) -> None:
-        if not re.fullmatch(r"[\w-]+?:\d+#[\w-]+?", container_definition):
+        if not re.fullmatch(r"[\w\-/:]+?:\d+#[\w\-/]+?", container_definition):
             raise InvalidParameterError(
                 "Parameter container_definition must be in format <task definition name>:<revision>#<container name>"
             )

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 from fbpcp.entity.cluster_instance import Cluster
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
-from fbpcp.error.pcp import PcpError
+from fbpcp.error.pcp import InvalidParameterError, PcpError
 from fbpcp.service.container_aws import AWSContainerService, AWS_API_INPUT_SIZE_LIMIT
 
 TEST_INSTANCE_ID_1 = "test-instance-id-1"
@@ -190,3 +190,19 @@ class TestAWSContainerService(unittest.TestCase):
         count = self.container_svc.get_current_instances_count()
         # Assert
         self.assertEqual(count, TEST_TASKS_COUNT)
+
+    def test_validate_container_definition_simple(self):
+        self.container_svc.validate_container_definition(
+            "pl-task-fake-business:2#pl-container-fake-business"
+        )
+
+    def test_validate_container_definition_complex(self):
+        # PCE service task definitions
+        self.container_svc.validate_container_definition(
+            "arn:aws:ecs:us-west-2:539290649537:task-definition/onedocker-task-shared-us-west-2:1#onedocker-container-shared-us-west-2"
+        )
+
+    def test_validate_container_definition_invalid(self):
+        # this is something we've seen in real runs
+        with self.assertRaises(InvalidParameterError):
+            self.container_svc.validate_container_definition("pl-task-fake-business:2#")


### PR DESCRIPTION
Summary:
## What

* expand regex for valid one docker task definition
* add unit tests for validation

## Why

* Current validation does not match PCE Service task definitions
* this is blocking the weekly release: https://fb.workplace.com/groups/988664215009283/posts/1148076639068039/?comment_id=1148111342397902

Differential Revision: D35369701

