### PR TITLE
Rename the gateways to follow the same pattern [2/n]

### DIFF
--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -13,7 +13,7 @@ from fbpcp.gateway.aws import AWSGateway
 from fbpcp.mapper.aws import map_ec2vpcpeering_to_vpcpeering
 
 
-class PCEEC2Gateway(AWSGateway):
+class EC2Gateway(AWSGateway):
     def __init__(
         self,
         region: str,

--- a/pce/gateway/iam.py
+++ b/pce/gateway/iam.py
@@ -18,7 +18,7 @@ from pce.entity.iam_role import (
 from pce.mapper.aws import map_attachedrolepolicies_to_rolepolicies
 
 
-class PCEIAMGateway(AWSGateway):
+class IAMGateway(AWSGateway):
     def __init__(
         self,
         region: str,

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -11,10 +11,10 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from fbpcp.entity.vpc_peering import VpcPeering, VpcPeeringRole, VpcPeeringState
-from pce.gateway.ec2 import PCEEC2Gateway
+from pce.gateway.ec2 import EC2Gateway
 
 
-class TestPCEEC2Gateway(TestCase):
+class TestEC2Gateway(TestCase):
     REGION = "us-west-2"
     TEST_AWS_ACCOUNT_ID = "123456789012"
     TEST_ACCEPTER_VPC_ID = "vpc-12345"
@@ -25,7 +25,7 @@ class TestPCEEC2Gateway(TestCase):
         self.aws_ec2 = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_ec2
-            self.ec2 = PCEEC2Gateway(self.REGION)
+            self.ec2 = EC2Gateway(self.REGION)
 
     def test_describe_availability_zones(self) -> None:
         # Arrange

--- a/pce/gateway/tests/test_iam.py
+++ b/pce/gateway/tests/test_iam.py
@@ -12,17 +12,17 @@ from unittest.mock import patch, call, MagicMock
 from pce.entity.iam_role import (
     IAMRole,
 )
-from pce.gateway.iam import PCEIAMGateway
+from pce.gateway.iam import IAMGateway
 
 REGION = "us-west-2"
 
 
-class TestPCEIAMGateway(TestCase):
+class TestIAMGateway(TestCase):
     def setUp(self) -> None:
         self.aws_iam = MagicMock()
         with patch("boto3.client") as mock_client:
             mock_client.return_value = self.aws_iam
-            self.iam = PCEIAMGateway(REGION)
+            self.iam = IAMGateway(REGION)
 
     def test_get_policies_for_role(self) -> None:
         test_role_name_1 = "test_role_1"
@@ -107,7 +107,7 @@ class TestPCEIAMGateway(TestCase):
 
         mock_paginator.paginate.assert_has_calls(
             [
-                call(RoleName=PCEIAMGateway._role_id_to_name(test_role_name))
+                call(RoleName=IAMGateway._role_id_to_name(test_role_name))
                 for test_role_name in test_expected_role_attached_policies.keys()
             ]
         )
@@ -115,17 +115,13 @@ class TestPCEIAMGateway(TestCase):
     def test_role_id_to_name_slashes(self) -> None:
         role_name = "application_abc/component_xyz/RDSAccess"
         self.assertEqual(
-            PCEIAMGateway._role_id_to_name(
-                f"arn:aws:iam::123456789012:role/{role_name}"
-            ),
+            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
             role_name,
         )
 
     def test_role_id_to_name_no_slashes(self) -> None:
         role_name = "RDSAccess"
         self.assertEqual(
-            PCEIAMGateway._role_id_to_name(
-                f"arn:aws:iam::123456789012:role/{role_name}"
-            ),
+            IAMGateway._role_id_to_name(f"arn:aws:iam::123456789012:role/{role_name}"),
             role_name,
         )

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -20,9 +20,9 @@ from fbpcp.entity.vpc_instance import Vpc
 from fbpcp.entity.vpc_peering import VpcPeeringState
 from fbpcp.service.pce_aws import PCE_ID_KEY
 from pce.entity.mpc_roles import MPCRoles
-from pce.gateway.ec2 import PCEEC2Gateway
+from pce.gateway.ec2 import EC2Gateway
 from pce.gateway.ecs import ECSGateway
-from pce.gateway.iam import PCEIAMGateway
+from pce.gateway.iam import IAMGateway
 from pce.gateway.logs_aws import LogsGateway
 from pce.validator.message_templates.error_message_templates import (
     NetworkingErrorTemplate,
@@ -83,16 +83,16 @@ class ValidationSuite:
         key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         role: Optional[MPCRoles] = None,
-        ec2_gateway: Optional[PCEEC2Gateway] = None,
-        iam_gateway: Optional[PCEIAMGateway] = None,
+        ec2_gateway: Optional[EC2Gateway] = None,
+        iam_gateway: Optional[IAMGateway] = None,
         ecs_gateway: Optional[ECSGateway] = None,
         logs_gateway: Optional[LogsGateway] = None,
     ) -> None:
         self.role: MPCRoles = role or MPCRoles.PARTNER
-        self.ec2_gateway: PCEEC2Gateway = ec2_gateway or PCEEC2Gateway(
+        self.ec2_gateway: EC2Gateway = ec2_gateway or EC2Gateway(
             region, key_id, key_data, config
         )
-        self.iam_gateway: PCEIAMGateway = iam_gateway or PCEIAMGateway(
+        self.iam_gateway: IAMGateway = iam_gateway or IAMGateway(
             region, key_id, key_data, config
         )
         self.ecs_gateway: ECSGateway = ecs_gateway or ECSGateway(


### PR DESCRIPTION
Summary: Rename external and internal gateways to follow the same pattern; removing PCE in the naming

Differential Revision: D35568496

