### PR TITLE
Integrate CertificateService to onedocker_runner

### DIFF
--- a/fbpcp/entity/certificate_request.py
+++ b/fbpcp/entity/certificate_request.py
@@ -14,4 +14,10 @@ from typing import Optional
 class CertificateRequest:
     key_algorithm: str
     key_size: int
-    cert_path: Optional[str]
+    cert_path: Optional[str] = None
+    country_name: Optional[str] = None
+    state_or_province_name: Optional[str] = None
+    locality_name: Optional[str] = None
+    orgnization_name: Optional[str] = None
+    common_name: Optional[str] = None
+    dns_name: Optional[str] = None

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -222,7 +222,8 @@ class OneDockerService(MetricsGetter):
     ) -> str:
         args_dict = {"exe_args": cmd_args, "version": version, "timeout": timeout}
         if certificate_request:
-            args_dict.update(asdict(certificate_request))
+            # TODO add test case for this logic T116947556
+            args_dict["certificate_request"] = str(asdict(certificate_request))
         runner_args = build_cmd_args(**args_dict)
         return ONEDOCKER_CMD_PREFIX.format(
             package_name=package_name,

--- a/onedocker/service/__init__.py
+++ b/onedocker/service/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/service/certificate.py
+++ b/onedocker/service/certificate.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import abc
+
+from fbpcp.entity.certificate_request import CertificateRequest
+
+
+class CertificateService(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self, cert_request: CertificateRequest) -> None:
+        pass
+
+    @abc.abstractmethod
+    def generate_certificate(
+        self,
+    ) -> str:
+        pass

--- a/onedocker/service/certificate_self_signed.py
+++ b/onedocker/service/certificate_self_signed.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import logging
+
+from fbpcp.entity.certificate_request import CertificateRequest
+from onedocker.service.certificate import CertificateService
+
+DEFAULT_CERT_PATH = "certificate"
+
+
+class SelfSignedCertificateService(CertificateService):
+    def __init__(self, cert_request: CertificateRequest) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.cert_request = cert_request
+
+    def generate_certificate(
+        self,
+    ) -> str:
+        # TODO implement this function in later diff
+        return ""


### PR DESCRIPTION
Summary:
This diff is to:
- create a basic interface of CertificateService
- Integrate CertificateService into onedocker_runner
- refactor the way that passing certificate request parameters into onedocker runner from passing individually to as a string. This way when we add or remove parameters in CertificateRequest, we don't need to make code change in onedocker service

Differential Revision: D35559421

