### PR TITLE
Refactor validator methods names to be derived from ValidatorStepNames

### DIFF
--- a/pce/validator/message_templates/validator_step_names.py
+++ b/pce/validator/message_templates/validator_step_names.py
@@ -11,11 +11,24 @@ from enum import Enum
 
 
 class ValidationStepNames(Enum):
-    CIDR = "CIDR"
-    VPC_PEERING = "VPC peering"
-    FIREWALL = "Firewall"
-    ROUTE_TABLE = "Route table"
-    SUBNETS = "Subnets"
-    CLUSTER_DEFINITION = "Cluster definition"
-    ROLE = "IAM roles"
-    LOG_GROUP = "Log group"
+    """
+    Enumerates the names of validation steps, each step corresponding to a
+    method of pce.validator.ValidationSuite called validate_{code_name}
+    """
+
+    VPC_CIDR = ("VPC CIDR", "vpc_cidr")
+    VPC_PEERING = ("VPC peering", "vpc_peering")
+    FIREWALL = ("Firewall", "firewall")
+    ROUTE_TABLE = ("Route table", "route_table")
+    SUBNETS = ("Subnets", "subnets")
+    CLUSTER_DEFINITION = ("Cluster definition", "cluster_definition")
+    IAM_ROLES = ("IAM roles", "iam_roles")
+    LOG_GROUP = ("Log group", "log_group")
+
+    def __init__(self, formatted_name: str, code_name: str) -> None:
+        """
+        set the Enum member values under better attribute names for
+        easier access later eg ValidationStepNames.VPC_CIDR.code_name
+        """
+        self.formatted_name = formatted_name
+        self.code_name = code_name

--- a/pce/validator/tests/validator_tests.py
+++ b/pce/validator/tests/validator_tests.py
@@ -167,7 +167,7 @@ class TestValidator(TestCase):
         )
         self.maxDiff = None
 
-    def _test_validate_private_cidr(
+    def _test_validate_vpc_cidr(
         self,
         cidr: str,
         expected_result: Optional[ValidationResult],
@@ -182,30 +182,30 @@ class TestValidator(TestCase):
 
         if expected_error_msg:
             with self.assertRaises(Exception) as ex:
-                self.validator.validate_private_cidr(pce)
+                self.validator.validate_vpc_cidr(pce)
             self.assertEquals(expected_error_msg, str(ex.exception))
             return
 
-        actual_result = self.validator.validate_private_cidr(pce)
+        actual_result = self.validator.validate_vpc_cidr(pce)
         self.assertEquals(expected_result, actual_result)
 
-    def test_validate_private_cidr_non_valid(self) -> None:
+    def test_validate_vpc_cidr_non_valid(self) -> None:
         for invalid_ip in ["non_valid", "10.1.1.300"]:
-            self._test_validate_private_cidr(
+            self._test_validate_vpc_cidr(
                 invalid_ip,
                 None,
                 f"'{invalid_ip}' does not appear to be an IPv4 or IPv6 network",
             )
 
-    def test_validate_private_cidr_success(self) -> None:
+    def test_validate_vpc_cidr_success(self) -> None:
         for invalid_ip in ["10.1.0.0/16", "10.1.10.0/24", "10.1.128.128/28"]:
-            self._test_validate_private_cidr(
+            self._test_validate_vpc_cidr(
                 invalid_ip, ValidationResult(ValidationResultCode.SUCCESS)
             )
 
-    def test_validate_private_cidr_fail(self) -> None:
+    def test_validate_vpc_cidr_fail(self) -> None:
         for invalid_ip in ["10.0.0.0/7", "173.16.0.0/12", "192.168.0.0/15"]:
-            self._test_validate_private_cidr(
+            self._test_validate_vpc_cidr(
                 invalid_ip,
                 ValidationResult(
                     ValidationResultCode.ERROR,
@@ -224,7 +224,7 @@ class TestValidator(TestCase):
         pce.pce_network.vpc.cidr = DEFAULT_PARTNER_VPC_CIDR
         self.validator.role = MPCRoles.PARTNER
         expected_result = ValidationResult(ValidationResultCode.SUCCESS)
-        actual_result = self.validator.validate_private_cidr(pce)
+        actual_result = self.validator.validate_vpc_cidr(pce)
         self.assertEquals(expected_result, actual_result)
 
     def test_validate_publisher_cidr(self) -> None:
@@ -232,7 +232,7 @@ class TestValidator(TestCase):
         pce.pce_network.vpc.cidr = DEFAULT_VPC_CIDR
         self.validator.role = MPCRoles.PUBLISHER
         expected_result = ValidationResult(ValidationResultCode.SUCCESS)
-        actual_result = self.validator.validate_private_cidr(pce)
+        actual_result = self.validator.validate_vpc_cidr(pce)
         self.assertEquals(expected_result, actual_result)
 
     def _test_validate_firewall(
@@ -766,7 +766,7 @@ class TestValidator(TestCase):
             ],
         )
 
-    def _test_validate_roles(
+    def _test_validate_iam_roles(
         self,
         task_role_id: RoleId,
         task_role_policy: IAMRole,
@@ -789,17 +789,17 @@ class TestValidator(TestCase):
 
         if expected_error_msg:
             with self.assertRaises(Exception) as ex:
-                self.validator.validate_roles(pce)
+                self.validator.validate_iam_roles(pce)
             self.assertEquals(expected_error_msg, str(ex.exception))
             return
 
-        actual_result = self.validator.validate_roles(pce)
+        actual_result = self.validator.validate_iam_roles(pce)
         self.assertEquals(expected_result, actual_result)
 
-    def test_validate_roles_bad_task_policy(self) -> None:
+    def test_validate_iam_roles_bad_task_policy(self) -> None:
         bad_task_policy: PolicyContents = TASK_POLICY.copy()
         bad_task_policy["Version"] = "2020-01-01"
-        self._test_validate_roles(
+        self._test_validate_iam_roles(
             TestValidator.TEST_TASK_ROLE_ID,
             IAMRole(
                 TestValidator.TEST_TASK_ROLE_ID,
@@ -820,9 +820,9 @@ class TestValidator(TestCase):
             ),
         )
 
-    def test_validate_roles_no_attached_policies(self) -> None:
+    def test_validate_iam_roles_no_attached_policies(self) -> None:
         task_policy: PolicyContents = TASK_POLICY.copy()
-        self._test_validate_roles(
+        self._test_validate_iam_roles(
             TestValidator.TEST_TASK_ROLE_ID,
             IAMRole(
                 # This role is not attached to the container
@@ -841,10 +841,10 @@ class TestValidator(TestCase):
             ),
         )
 
-    def test_validate_roles_more_policies_than_expected(self) -> None:
+    def test_validate_iam_roles_more_policies_than_expected(self) -> None:
         additional_policy_name = "task_policy_name_additional"
         task_policy: PolicyContents = TASK_POLICY.copy()
-        self._test_validate_roles(
+        self._test_validate_iam_roles(
             TestValidator.TEST_TASK_ROLE_ID,
             IAMRole(
                 TestValidator.TEST_TASK_ROLE_ID,

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -103,7 +103,7 @@ class ValidationSuite:
             region, key_id, key_data, config
         )
 
-    def validate_private_cidr(self, pce: PCE) -> ValidationResult:
+    def validate_vpc_cidr(self, pce: PCE) -> ValidationResult:
         default_vpc_cidr = (
             DEFAULT_PARTNER_VPC_CIDR
             if self.role == MPCRoles.PARTNER
@@ -455,19 +455,13 @@ class ValidationSuite:
         """
         with click.progressbar(
             [
-                (self.validate_private_cidr, ValidationStepNames.CIDR),
-                (self.validate_vpc_peering, ValidationStepNames.VPC_PEERING),
-                (self.validate_firewall, ValidationStepNames.FIREWALL),
-                (self.validate_route_table, ValidationStepNames.ROUTE_TABLE),
-                (self.validate_subnets, ValidationStepNames.SUBNETS),
                 (
-                    self.validate_cluster_definition,
-                    ValidationStepNames.CLUSTER_DEFINITION,
-                ),
-                (self.validate_roles, ValidationStepNames.ROLE),
-                (self.validate_log_group, ValidationStepNames.LOG_GROUP),
+                    self.__getattribute__(f"validate_{step.code_name}"),
+                    step.formatted_name,
+                )
+                for step in ValidationStepNames
             ],
-            item_show_func=lambda i: str(i[1].value) if i else "",
+            item_show_func=lambda i: str(i[1]) if i else "",
             label="Validating PCE...",
         ) as validation_functions:
             return [
@@ -500,7 +494,7 @@ class ValidationSuite:
             ]
         )
 
-    def validate_roles(self, pce: PCE) -> ValidationResult:
+    def validate_iam_roles(self, pce: PCE) -> ValidationResult:
         """
         Ensure that the container task execution role has the proper policy (`TASK_POLICY`) among those attached to it.
         """


### PR DESCRIPTION
Summary:
To prepare for implementing --skip-step functionality to optionally skip some PCE validator steps, this diff introduces the "code_name" value in the ValidationStepNames enum, which is a lowercased, underscored name of the existing step name.

The `code_name` value (without spaces and mixed case characters) is easier to enter on the command line as an argument to --skip-step, and is also the way most `validate_*` methods are named in the ValidationSuite class, corresponding to each ValidationStepNames.
This diff also renames the few validator methods that did not follow the pattern of being named "validate_{code_name}" for eg `validate_roles` -> `validate_iam_roles`

Differential Revision: D35424006

