### PR TITLE
Add cryptography gateway to holds logic with pyca/cryptography

### DIFF
--- a/fbpcp/entity/certificate_request.py
+++ b/fbpcp/entity/certificate_request.py
@@ -6,18 +6,62 @@
 
 # pyre-strict
 
+import ast
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
+
+
+class KeyAlgorithm(Enum):
+    # For now we only support RSA since it is one of the most common algorithms, will add more key algorithms in the future
+    RSA = "RSA"
+
+    @classmethod
+    def has_member(cls, name: str) -> bool:
+        return name in cls.__members__
 
 
 @dataclass
 class CertificateRequest:
-    key_algorithm: str
+    key_algorithm: KeyAlgorithm
     key_size: int
-    cert_path: Optional[str] = None
-    country_name: Optional[str] = None
-    state_or_province_name: Optional[str] = None
-    locality_name: Optional[str] = None
-    orgnization_name: Optional[str] = None
-    common_name: Optional[str] = None
-    dns_name: Optional[str] = None
+    passphrase: str
+    cert_path: Optional[str]
+    private_key_name: Optional[str]
+    country_name: Optional[str]
+    state_or_province_name: Optional[str]
+    locality_name: Optional[str]
+    organization_name: Optional[str]
+    common_name: Optional[str]
+    dns_name: Optional[str]
+
+    @classmethod
+    def create_instance(cls, cert_params: str) -> "CertificateRequest":
+        try:
+            cert_params_dict = ast.literal_eval(cert_params)
+        except Exception as err:
+            raise Exception(
+                f"An error was raised when unpack cert_params for CertificateRequest {cert_params}: {err}"
+            )
+        required_keys = {"key_algorithm", "key_size", "passphrase"}
+        if not required_keys.issubset(set(cert_params_dict.keys())):
+            raise Exception(
+                f"One of the required parameters {required_keys} is missing in cert_params: {cert_params_dict.keys()}"
+            )
+        key_algorithm_str = cert_params_dict["key_algorithm"]
+        if not KeyAlgorithm.has_member(key_algorithm_str):
+            raise Exception(f"key_algorithm {key_algorithm_str} is not supported")
+
+        return cls(
+            key_algorithm=KeyAlgorithm[key_algorithm_str],
+            key_size=cert_params_dict["key_size"],
+            passphrase=cert_params_dict["passphrase"],
+            cert_path=cert_params_dict.get("cert_path", None),
+            private_key_name=cert_params_dict.get("private_key_name", None),
+            country_name=cert_params_dict.get("country_name", None),
+            state_or_province_name=cert_params_dict.get("state_or_province_name", None),
+            locality_name=cert_params_dict.get("locality_name", None),
+            organization_name=cert_params_dict.get("organization_name", None),
+            common_name=cert_params_dict.get("common_name", None),
+            dns_name=cert_params_dict.get("dns_name", None),
+        )

--- a/onedocker/gateway/__init__.py
+++ b/onedocker/gateway/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/gateway/cryptography.py
+++ b/onedocker/gateway/cryptography.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Union
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fbpcp.entity.certificate_request import KeyAlgorithm
+
+
+class CryptographyGateway:
+    def _convert_str_to_bytes(self, s: str) -> bytes:
+        return s.encode("utf-8")
+
+    def generate_private_key(
+        self,
+        key_algorithm: KeyAlgorithm,
+        key_size: int,
+    ) -> Union[rsa.RSAPrivateKeyWithSerialization]:
+        if key_algorithm == KeyAlgorithm.RSA:
+            # The public_exponent indicates what one mathematical property of the key generation will be. Official guide suggests always use 65537. (https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/)
+            public_exponent = 65537
+            key = rsa.generate_private_key(
+                public_exponent=public_exponent,
+                key_size=key_size,
+            )
+            return key
+        else:
+            # For now we only support RSA since it is one of the most common algorithms, will add more key algorithms in the future
+            raise NotImplementedError
+
+    def get_key_private_bytes(
+        self,
+        key: Union[rsa.RSAPrivateKeyWithSerialization],
+        passphrase: str,
+    ) -> bytes:
+        key_bytes = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.BestAvailableEncryption(
+                self._convert_str_to_bytes(passphrase)
+            ),
+        )
+        return key_bytes

--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -23,7 +23,6 @@ Options:
     --cert_params=<cert_params>         string format of CertificateRequest dictionary if a TLS certificate is requested
     --verbose                           Set logging level to DEBUG.
 """
-import ast
 import logging
 import os
 import resource
@@ -233,16 +232,6 @@ def _read_config(
     return default_val
 
 
-def _get_certificate_request(
-    cert_params: Optional[str],
-) -> Optional[CertificateRequest]:
-    if not cert_params:
-        return None
-    else:
-        # TODO add test case for this logic T116947687
-        return CertificateRequest(**ast.literal_eval(cert_params))
-
-
 def _generate_certificate(certificate_request: CertificateRequest) -> Optional[str]:
     try:
         logger.info("generating certificate")
@@ -292,7 +281,7 @@ def main() -> None:
         ONEDOCKER_EXE_PATH,
         DEFAULT_EXE_FOLDER,
     )
-    certificate_request = _get_certificate_request(arguments["--cert_params"])
+    certificate_request = CertificateRequest.create_instance(arguments["--cert_params"])
     _run_package(
         repository_path=repository_path,
         exe_path=exe_path,

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "psutil==5.8.0",
     "click==7.1.2",
     "kubernetes==12.0.1",
+    "cryptography==36.0.2",
 ]
 
 with open("README.md", encoding="utf-8") as f:


### PR DESCRIPTION
Summary:
Add cryptography gateway to wrap the logics that interact with pyca/cryptography package to generate key/certificates, etc.
Unittests will be added in later diff once interface is finalized.

Differential Revision: D35618333

