### PR TITLE
Integrate CryptographyGateway to SelfSignedCertificateService for generating private key

### DIFF
--- a/onedocker/service/certificate_self_signed.py
+++ b/onedocker/service/certificate_self_signed.py
@@ -6,20 +6,59 @@
 
 # pyre-strict
 import logging
+import os
 
 from fbpcp.entity.certificate_request import CertificateRequest
+from onedocker.gateway.cryptography import CryptographyGateway
 from onedocker.service.certificate import CertificateService
 
 DEFAULT_CERT_PATH = "certificate"
+DEFAULT_PRIVATE_KEY_NAME = "private_key.pem"
+
+
+def str_to_bytes(s: str) -> bytes:
+    return s.encode("utf-8")
 
 
 class SelfSignedCertificateService(CertificateService):
     def __init__(self, cert_request: CertificateRequest) -> None:
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.cert_request = cert_request
+        self.cert_path: str = self.cert_request.cert_path or DEFAULT_CERT_PATH
+        self.private_key_path: str = os.path.join(
+            self.cert_path,
+            (self.cert_request.private_key_name or DEFAULT_PRIVATE_KEY_NAME),
+        )
+        self.crypt_gateway = CryptographyGateway()
+
+    def _write_bytes_to_file(self, filename: str, content: bytes) -> None:
+        try:
+            with open(filename, "wb") as f:
+                f.write(content)
+        except Exception as err:
+            self.logger.exception(
+                f"An error was raised in CertificateService while writing to file {filename}, error: {err}"
+            )
 
     def generate_certificate(
         self,
     ) -> str:
-        # TODO implement this function in later diff
-        return ""
+        # create dir for private key and certificate
+        os.makedirs(self.cert_path, exist_ok=True)
+
+        # generate private key
+        private_key = self.crypt_gateway.generate_private_key(
+            self.cert_request.key_algorithm,
+            self.cert_request.key_size,
+        )
+
+        # write private key to file
+        key_byte = self.crypt_gateway.get_key_private_bytes(
+            private_key,
+            self.cert_request.passphrase,
+        )
+        self._write_bytes_to_file(self.private_key_path, key_byte)
+
+        # TODO implement the certificate signing part
+
+        return self.cert_path


### PR DESCRIPTION
Summary: This diff is to integrate the private key generation part of CryptographyGateway into SelfSignedCertificateService. The certificate generation part will be implemented in later diff

Differential Revision: D35614969

