### PR TITLE
Add entity CryptographyKeyPair to holds the key pair information from CryptographyGateway

### DIFF
--- a/onedocker/entity/key_pair_details.py
+++ b/onedocker/entity/key_pair_details.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+
+@dataclass
+class KeyPairDetails:
+    private_key_pem: bytes
+    public_key_pem: bytes

--- a/onedocker/gateway/cryptography.py
+++ b/onedocker/gateway/cryptography.py
@@ -7,42 +7,87 @@
 # pyre-strict
 from typing import Union
 
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
 from fbpcp.entity.certificate_request import KeyAlgorithm
+from onedocker.entity.key_pair_details import KeyPairDetails
 
 
 class CryptographyGateway:
     def _convert_str_to_bytes(self, s: str) -> bytes:
         return s.encode("utf-8")
 
-    def generate_private_key(
+    def generate_key_pair(
         self,
         key_algorithm: KeyAlgorithm,
         key_size: int,
-    ) -> Union[rsa.RSAPrivateKeyWithSerialization]:
+        passphrase: str,
+    ) -> KeyPairDetails:
+        private_key = self._generate_private_key(key_algorithm, key_size)
+        private_key_pem = self.get_private_key_pem(private_key, passphrase)
+        public_key_pem = self.get_public_key_pem(private_key.public_key())
+        return KeyPairDetails(
+            private_key_pem=private_key_pem,
+            public_key_pem=public_key_pem,
+        )
+
+    def _generate_private_key(
+        self,
+        key_algorithm: KeyAlgorithm,
+        key_size: int,
+    ) -> Union[RSAPrivateKeyWithSerialization]:
         if key_algorithm == KeyAlgorithm.RSA:
             # The public_exponent indicates what one mathematical property of the key generation will be. Official guide suggests always use 65537. (https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/)
             public_exponent = 65537
-            key = rsa.generate_private_key(
+            private_key = rsa.generate_private_key(
                 public_exponent=public_exponent,
                 key_size=key_size,
             )
-            return key
+            return private_key
         else:
             # For now we only support RSA since it is one of the most common algorithms, will add more key algorithms in the future
             raise NotImplementedError
 
-    def get_key_private_bytes(
+    def get_private_key_pem(
         self,
-        key: Union[rsa.RSAPrivateKeyWithSerialization],
+        private_key: Union[rsa.RSAPrivateKeyWithSerialization],
         passphrase: str,
     ) -> bytes:
-        key_bytes = key.private_bytes(
+        key_pem = private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.BestAvailableEncryption(
                 self._convert_str_to_bytes(passphrase)
             ),
         )
-        return key_bytes
+        return key_pem
+
+    def load_private_key(
+        self,
+        key_pem: bytes,
+        passphrase: str,
+    ) -> Union[rsa.RSAPrivateKey]:
+        private_key = load_pem_private_key(
+            key_pem, self._convert_str_to_bytes(passphrase), default_backend()
+        )
+        return private_key
+
+    def get_public_key_pem(
+        self,
+        public_key: Union[rsa.RSAPublicKey],
+    ) -> bytes:
+        key_pem = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return key_pem
+
+    def load_public_key(self, key_pem: bytes) -> Union[rsa.RSAPublicKey]:
+        public_key = load_pem_public_key(key_pem, default_backend())
+        return public_key

--- a/onedocker/service/certificate_self_signed.py
+++ b/onedocker/service/certificate_self_signed.py
@@ -46,18 +46,15 @@ class SelfSignedCertificateService(CertificateService):
         # create dir for private key and certificate
         os.makedirs(self.cert_path, exist_ok=True)
 
-        # generate private key
-        private_key = self.crypt_gateway.generate_private_key(
+        # generate key pair
+        key_pair = self.crypt_gateway.generate_key_pair(
             self.cert_request.key_algorithm,
             self.cert_request.key_size,
+            self.cert_request.passphrase,
         )
 
         # write private key to file
-        key_byte = self.crypt_gateway.get_key_private_bytes(
-            private_key,
-            self.cert_request.passphrase,
-        )
-        self._write_bytes_to_file(self.private_key_path, key_byte)
+        self._write_bytes_to_file(self.private_key_path, key_pair.private_key_pem)
 
         # TODO implement the certificate signing part
 

--- a/onedocker/tests/gateway/test_cryptography.py
+++ b/onedocker/tests/gateway/test_cryptography.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKeyWithSerialization,
+)
+from fbpcp.entity.certificate_request import KeyAlgorithm
+from onedocker.entity.key_pair_details import KeyPairDetails
+from onedocker.gateway.cryptography import CryptographyGateway
+
+
+def write_bytes_to_file(filename: str, content: bytes) -> None:
+    try:
+        with open(filename, "wb") as f:
+            f.write(content)
+    except Exception as err:
+        print(
+            f"An error was raised in CertificateService while writing to file {filename}, error: {err}"
+        )
+
+
+class TestCryptographyGateway(unittest.TestCase):
+    TEST_KEY_ALGORITHM = KeyAlgorithm.RSA
+    TEST_KEY_SIZE = 4096
+    TEST_PASSPHRASE = "test"
+
+    def test_generate_key_pair(self):
+        # Arrange
+        gw = CryptographyGateway()
+
+        # Act
+        key_pair = gw.generate_key_pair(
+            self.TEST_KEY_ALGORITHM, self.TEST_KEY_SIZE, self.TEST_PASSPHRASE
+        )
+
+        # Assert
+        self.assertIsInstance(key_pair, KeyPairDetails)
+        self.assertIsInstance(key_pair.public_key_pem, bytes)
+        self.assertIsInstance(key_pair.private_key_pem, bytes)
+
+    def test_get_private_key_pem(self):
+        # Arrange
+        gw = CryptographyGateway()
+        test_key = gw._generate_private_key(self.TEST_KEY_ALGORITHM, self.TEST_KEY_SIZE)
+
+        # Act
+        private_key_pem = gw.get_private_key_pem(test_key, self.TEST_PASSPHRASE)
+        unpacked_private_key = gw.load_private_key(
+            private_key_pem, self.TEST_PASSPHRASE
+        )
+        test_key_pem = gw.get_private_key_pem(
+            unpacked_private_key, self.TEST_PASSPHRASE
+        )
+
+        # Assert
+        self.assertIsInstance(private_key_pem, bytes)
+        self.assertIsInstance(test_key_pem, bytes)
+
+    def test_get_public_key_pem(self):
+        # Arrange
+        gw = CryptographyGateway()
+
+        # Act
+        test_key_pair = gw.generate_key_pair(
+            self.TEST_KEY_ALGORITHM, self.TEST_KEY_SIZE, self.TEST_PASSPHRASE
+        )
+
+        test_public_pem = test_key_pair.public_key_pem
+        unpack_public_pem = gw.get_public_key_pem(gw.load_public_key(test_public_pem))
+
+        # Assert
+        self.assertIsInstance(test_public_pem, bytes)
+        self.assertEqual(test_public_pem, unpack_public_pem)
+
+    def test_generate_private_key(self):
+        # Arrange
+        gw = CryptographyGateway()
+        test_rsa_algorithm = KeyAlgorithm.RSA
+        test_unsupported_algorithm = "TEST"
+
+        # Act
+        test_rsa_key = gw._generate_private_key(test_rsa_algorithm, self.TEST_KEY_SIZE)
+
+        # Assert
+        self.assertIsInstance(test_rsa_key, RSAPrivateKeyWithSerialization)
+        with self.assertRaises(NotImplementedError):
+            gw._generate_private_key(test_unsupported_algorithm, self.TEST_KEY_SIZE)


### PR DESCRIPTION
Summary:
This diff is to:
- add entity CryptographyKeyPair to holds the key pair information from CryptographyGateway
- make corresponding change to CryptographyGateway and SelfSignedCertificateService to adopt this change
- add unit test for CryptographyGateway

Differential Revision: D35682261

