### PR TITLE
Update oss Pyre configuration to preemptively guard again upcoming semantic changes

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,4 +1,5 @@
 {
+  "site_package_search_strategy": "all",
   "source_directories": [
     "fbpcp",
     "onedocker",


### PR DESCRIPTION
Summary:
Pyre is going to have a semantic change in its configuration: D35695552.

Basically, we are changing the default behavior on how search paths are discovered. Pre-existing configurations need to explicitly opt-in to the old behavior -- otherwise, they may risk breaking their type check setups.

The added option will lead to a Pyre warning for now, but that warning would go away on the next Pyre upgrade.

Differential Revision: D35724336

