### PR TITLE
Create generate_certificate_pem function in CryptographyGateway

### DIFF
--- a/onedocker/tests/gateway/test_cryptography.py
+++ b/onedocker/tests/gateway/test_cryptography.py
@@ -6,9 +6,11 @@
 
 import unittest
 
+from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric.rsa import (
     RSAPrivateKeyWithSerialization,
 )
+from cryptography.x509.oid import NameOID
 from fbpcp.entity.certificate_request import KeyAlgorithm
 from onedocker.entity.key_pair_details import KeyPairDetails
 from onedocker.gateway.cryptography import CryptographyGateway
@@ -28,6 +30,12 @@ class TestCryptographyGateway(unittest.TestCase):
     TEST_KEY_ALGORITHM = KeyAlgorithm.RSA
     TEST_KEY_SIZE = 4096
     TEST_PASSPHRASE = "test"
+    TEST_COUNTRY_NAME = "US"
+    TEST_STATE_OR_PROVINCE_NAME = "California"
+    TEST_LOCALITY_NAME = "San Francisco"
+    TEST_ORGANIZATION_NAME = "OneDocker"
+    TEST_COMMON_NAME = "test_site.com"
+    TEST_DNS_NAME = "localhost"
 
     def test_generate_key_pair(self):
         # Arrange
@@ -90,3 +98,40 @@ class TestCryptographyGateway(unittest.TestCase):
         self.assertIsInstance(test_rsa_key, RSAPrivateKeyWithSerialization)
         with self.assertRaises(NotImplementedError):
             gw._generate_private_key(test_unsupported_algorithm, self.TEST_KEY_SIZE)
+
+    def test_generate_certificate_pem(self):
+        # Arrange
+        gw = CryptographyGateway()
+        test_subject_name = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COUNTRY_NAME, self.TEST_COUNTRY_NAME),
+                x509.NameAttribute(
+                    NameOID.STATE_OR_PROVINCE_NAME, self.TEST_STATE_OR_PROVINCE_NAME
+                ),
+                x509.NameAttribute(NameOID.LOCALITY_NAME, self.TEST_LOCALITY_NAME),
+                x509.NameAttribute(NameOID.COMMON_NAME, self.TEST_COMMON_NAME),
+            ]
+        )
+        test_issuer_name = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COUNTRY_NAME, self.TEST_COUNTRY_NAME),
+                x509.NameAttribute(
+                    NameOID.ORGANIZATION_NAME, self.TEST_ORGANIZATION_NAME
+                ),
+            ]
+        )
+        test_key_pair = gw.generate_key_pair(
+            self.TEST_KEY_ALGORITHM, self.TEST_KEY_SIZE, self.TEST_PASSPHRASE
+        )
+
+        # Act
+        test_certificate_pem = gw.generate_certificate_pem(
+            subject_name=test_subject_name,
+            issuer_name=test_issuer_name,
+            key_pair_details=test_key_pair,
+            passphrase=self.TEST_PASSPHRASE,
+            days_valid=2,
+        )
+
+        # Assert
+        self.assertIsInstance(test_certificate_pem, bytes)


### PR DESCRIPTION
Summary: This diff is to create generate_certificate_pem function in CryptographyGateway  and add unittest. Integration will in next diff.

Differential Revision: D35738884

