### PR TITLE
Release fbpcp 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,10 @@ Release PCE validator and update onedocker dependencies
 
 ### Description of changes
 * Update the API in MPC Service to take envrionment variables to support onedocker package repository overrides.
+
+## 0.2.7 -> 0.2.8
+### Types of changes
+* New feature (non-breaking change which adds functionality)
+
+### Description of changes
+* Added support for skipping some validation steps in PCE Validator with the --skip-step CLI params

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.7",
+    version="0.2.8",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: Release fbpcp 0.2.8 with recent new features in PCE Validator to skip some validation steps

Differential Revision: D35792297

