### PR TITLE
Create RepoMonitorService interface and add methods to S3Gateway

### DIFF
--- a/fbpcp/entity/policy_statement.py
+++ b/fbpcp/entity/policy_statement.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class PolicyStatement:
+    """AWS Policy Statement: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html"""
+
+    effect: str
+    principals: List[str]
+    actions: List[str]
+    resources: List[str]
+    sid: str = ""
+
+
+@dataclass
+class PublicAccessBlockConfig:
+    """AWS PublicAccessBlockConfiguration: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html"""
+
+    block_public_acls: bool
+    ignore_public_acls: bool
+    block_public_policy: bool
+    restrict_public_buckets: bool

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -14,6 +14,7 @@ from fbpcp.entity.cluster_instance import Cluster, ClusterStatus
 from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.entity.firewall_ruleset import FirewallRule, FirewallRuleset
+from fbpcp.entity.policy_statement import PolicyStatement
 from fbpcp.entity.route_table import (
     RouteTable,
     Route,
@@ -24,7 +25,12 @@ from fbpcp.entity.route_table import (
 from fbpcp.entity.subnet import Subnet
 from fbpcp.entity.vpc_instance import Vpc, VpcState
 from fbpcp.entity.vpc_peering import VpcPeering, VpcPeeringRole, VpcPeeringState
-from fbpcp.util.aws import convert_list_to_dict, get_container_definition_id
+from fbpcp.util.aws import (
+    convert_list_to_dict,
+    get_container_definition_id,
+    convert_obj_to_list,
+    get_json_values,
+)
 
 
 def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
@@ -219,4 +225,17 @@ def map_ecstaskdefinition_to_containerdefinition(
         environment,
         task_role_id,
         tags,
+    )
+
+
+def map_awsstatement_to_policystatement(statement: Dict[str, Any]) -> PolicyStatement:
+    # resource is optional for s3 policy
+    resources = (
+        convert_obj_to_list(statement["Resource"]) if "Resource" in statement else []
+    )
+    return PolicyStatement(
+        effect=statement["Effect"],
+        principals=get_json_values(statement["Principal"]),
+        actions=convert_obj_to_list(statement["Action"]),
+        resources=resources,
     )

--- a/fbpcp/util/aws.py
+++ b/fbpcp/util/aws.py
@@ -8,7 +8,7 @@
 
 
 from functools import reduce
-from typing import Dict, List, Optional, Tuple
+from typing import Union, Dict, List, Optional, Tuple, Any
 
 
 def convert_dict_to_list(
@@ -48,6 +48,24 @@ def convert_list_to_dict(
         return reduce(lambda x, y: {**x, **{y[key]: y[value]}}, target_list, {})
     else:
         return {}
+
+
+# pyre-ignore
+def convert_obj_to_list(obj: Any) -> List:
+    return obj if isinstance(obj, list) else [obj]
+
+
+def get_json_values(json_elem: Union[str, Dict[str, Any]]) -> List[str]:
+    """
+    Input examples: {"k1": ["v1", "v2"], "k2": "v3"}
+    Output examples: ["v1", "v2", "v3"]
+    """
+    if isinstance(json_elem, str):
+        return [json_elem]
+    ret = []
+    for val in json_elem.values():
+        ret.extend(convert_obj_to_list(val))
+    return ret
 
 
 def prepare_tags(tags: Dict[str, str]) -> Dict[str, str]:

--- a/tests/gateway/test_s3.py
+++ b/tests/gateway/test_s3.py
@@ -80,6 +80,43 @@ class TestS3Gateway(unittest.TestCase):
         gw.client.copy.assert_called()
 
     @patch("boto3.client")
+    def test_get_policy_statements(self, BotoClient):
+        # Arrage
+        gw = S3Gateway(REGION)
+        gw.client = BotoClient()
+        response = {
+            "Policy": '{"Version":"2008-10-17","Statement":[]}',
+            "ResponseMetadata": {
+                "...": "...",
+            },
+        }
+        gw.client.get_bucket_policy = MagicMock(return_value=response)
+        # Act
+        policy_statements = gw.get_policy_statements(TEST_BUCKET)
+        # Assert
+        gw.client.get_bucket_policy.assert_called_with(Bucket=TEST_BUCKET)
+        self.assertEqual(len(policy_statements), 0)
+
+    @patch("boto3.client")
+    def test_get_public_access_block(self, BotoClient):
+        # Arrage
+        gw = S3Gateway(REGION)
+        gw.client = BotoClient()
+        response = {
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            }
+        }
+        gw.client.get_public_access_block = MagicMock(return_value=response)
+        # Act
+        gw.get_public_access_block(TEST_BUCKET)
+        # Assert
+        gw.client.get_public_access_block.assert_called_with(Bucket=TEST_BUCKET)
+
+    @patch("boto3.client")
     def test_object_exists(self, BotoClient):
         gw = S3Gateway(REGION)
         gw.client = BotoClient()

--- a/tests/mapper/test_aws.py
+++ b/tests/mapper/test_aws.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from fbpcp.entity.cloud_cost import CloudCost, CloudCostItem
 from fbpcp.entity.cluster_instance import ClusterStatus, Cluster
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
+from fbpcp.entity.policy_statement import PolicyStatement
 from fbpcp.entity.route_table import (
     Route,
     RouteState,
@@ -23,6 +24,7 @@ from fbpcp.mapper.aws import (
     map_ec2subnet_to_subnet,
     map_cecost_to_cloud_cost,
     map_ec2route_to_route,
+    map_awsstatement_to_policystatement,
 )
 
 
@@ -319,3 +321,22 @@ class TestAWSMapper(unittest.TestCase):
         self.assertEqual(
             map_ec2route_to_route(igw_route_response), expected_parsed_route
         )
+
+    def test_map_awsstatement_to_policystatement(self):
+        # Arrange
+        statement = {
+            "Effect": "Allow",
+            "Principal": {"AWS": "account_id"},
+            "Action": ["s3:ListAllMyBuckets"],
+            "Resource": "arn:aws:s3:::*",
+        }
+        # Act
+        policy_stmt = map_awsstatement_to_policystatement(statement)
+        # Assert
+        expected_stmt = PolicyStatement(
+            effect="Allow",
+            principals=["account_id"],
+            actions=["s3:ListAllMyBuckets"],
+            resources=["arn:aws:s3:::*"],
+        )
+        self.assertEqual(policy_stmt, expected_stmt)


### PR DESCRIPTION
Summary: Create RepoMonitorService to check bucket policy and public access block. Will create AWSRepoMonitorService in a later diff that uses the added s3 methods.

Differential Revision: D35831406

