### PR TITLE
OneDocker binary access optimization

### DIFF
--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -86,7 +86,8 @@ def _prepare_executable(
     exe_name = _parse_package_name(package_name)
 
     executable = f"{exe_path}{exe_name}"
-    os.chmod(executable, 0o755)
+    if not os.access(executable, os.X_OK):
+        os.chmod(executable, 0o755)
     return executable
 
 


### PR DESCRIPTION
Summary:
Previously, we force to chmod to 755 on any executables we want to run.
Now, we firstly check whether the binary has x before chmod before chmod.

Differential Revision: D35636713

