### PR TITLE
Output user arn when runing PCE validator

### DIFF
--- a/pce/gateway/sts.py
+++ b/pce/gateway/sts.py
@@ -27,6 +27,6 @@ class STSGateway(AWSGateway):
     def get_caller_arn(
         self,
     ) -> str:
-        response = self.client.get_caller_arn()
+        response = self.client.get_caller_identity()
 
         return response["Arn"]

--- a/pce/gateway/tests/test_sts.py
+++ b/pce/gateway/tests/test_sts.py
@@ -31,7 +31,9 @@ class TestSTSGateway(TestCase):
             "Arn": "foo",
         }
 
-        self.aws_sts.get_caller_arn = MagicMock(return_value=client_return_response)
+        self.aws_sts.get_caller_identity = MagicMock(
+            return_value=client_return_response
+        )
 
         expected_arn = "foo"
 
@@ -40,4 +42,4 @@ class TestSTSGateway(TestCase):
 
         # Assert
         self.assertEqual(expected_arn, arn)
-        self.aws_sts.get_caller_arn.assert_called()
+        self.aws_sts.get_caller_identity.assert_called()


### PR DESCRIPTION
Summary: Add code to output the user ARN when running PCE validator

Differential Revision: D36009643

