### PR TITLE
Enable pyre-strict in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Summary:
Enabled pyre-strict in
fbcode/measurement/private_measurement/pcp/oss/setup.py. Ran pyre and saw no issues.

Reviewed By: jiecongwang

Differential Revision: D35436160

