### PR TITLE
Add get policy methods to StorageService

### DIFF
--- a/fbpcp/service/storage.py
+++ b/fbpcp/service/storage.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import List
 
 from fbpcp.entity.file_information import FileInfo
+from fbpcp.entity.policy_statement import PolicyStatement, PublicAccessBlockConfig
 
 
 class PathType(Enum):
@@ -61,4 +62,12 @@ class StorageService(abc.ABC):
 
     @abc.abstractmethod
     def list_folders(self, filename: str) -> List[str]:
+        pass
+
+    @abc.abstractmethod
+    def get_bucket_policy_statements(self, bucket: str) -> List[PolicyStatement]:
+        pass
+
+    @abc.abstractmethod
+    def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
         pass

--- a/fbpcp/service/storage_gcs.py
+++ b/fbpcp/service/storage_gcs.py
@@ -10,6 +10,7 @@ import os
 from typing import Any, Dict, Optional, List
 
 from fbpcp.entity.file_information import FileInfo
+from fbpcp.entity.policy_statement import PolicyStatement, PublicAccessBlockConfig
 from fbpcp.gateway.gcs import GCSGateway
 from fbpcp.service.storage import StorageService, PathType
 from fbpcp.util.gcspath import GCSPath
@@ -275,3 +276,9 @@ class GCSStorageService(StorageService):
             if blob_name.endswith("/"):
                 folders.append(blob_name)
         return folders
+
+    def get_bucket_policy_statements(self, bucket: str) -> List[PolicyStatement]:
+        raise NotImplementedError
+
+    def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
+        raise NotImplementedError

--- a/fbpcp/service/storage_s3.py
+++ b/fbpcp/service/storage_s3.py
@@ -12,6 +12,7 @@ from os.path import join, normpath, relpath
 from typing import Any, Dict, Optional, List
 
 from fbpcp.entity.file_information import FileInfo
+from fbpcp.entity.policy_statement import PolicyStatement, PublicAccessBlockConfig
 from fbpcp.gateway.s3 import S3Gateway
 from fbpcp.service.storage import PathType, StorageService
 from fbpcp.util.s3path import S3Path
@@ -210,3 +211,9 @@ class S3StorageService(StorageService):
     def list_folders(self, filename: str) -> List[str]:
         s3_path = S3Path(filename)
         return self.s3_gateway.list_folders(s3_path.bucket, s3_path.key)
+
+    def get_bucket_policy_statements(self, bucket: str) -> List[PolicyStatement]:
+        return self.s3_gateway.get_policy_statements(bucket)
+
+    def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
+        return self.s3_gateway.get_public_access_block(bucket)


### PR DESCRIPTION
Summary:
Add get bucket policy/access block methods to StorageService. In later diff, the monitoring script will call the StorageService to get bucket policies.

Since RepoMonitor is only for AWS currently, NotImplementedError is thrown for GCS side.

Differential Revision: D36177335

