### PR TITLE
Add get_cluster function in OneDocker Service

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -56,6 +56,14 @@ class OneDockerService(MetricsGetter):
         self.metrics: Final[Optional[MetricsEmitter]] = metrics
         self.logger: logging.Logger = logging.getLogger(__name__)
 
+    def get_cluster(self) -> str:
+        """Get the cluster of the container service
+
+        Returns:
+            The container service's cluster name
+        """
+        return self.container_svc.get_cluster()
+
     def has_metrics(self) -> bool:
         return self.metrics is not None
 

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -33,6 +33,7 @@ TEST_KEY_SIZE = 4096
 TEST_PASSPHRASE = "test"
 TEST_ORGANIZATION_NAME = "Test Company"
 TEST_COUNTRY_NAME = "US"
+TEST_CLUSTER_STR = "Test Cluster"
 
 
 class TestOneDockerServiceSync(unittest.TestCase):
@@ -243,6 +244,18 @@ class TestOneDockerServiceSync(unittest.TestCase):
         self.container_svc.get_instances.assert_called_with(
             [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
         )
+
+    def test_get_cluster(self):
+        # Arrange
+        expected_result = TEST_CLUSTER_STR
+        self.container_svc.get_cluster.return_value = expected_result
+
+        # Act
+        cluster = self.onedocker_svc.get_cluster()
+
+        # Assert
+        self.assertEqual(cluster, expected_result)
+        self.container_svc.get_cluster.assert_called_with()
 
 
 class TestOneDockerServiceAsync(IsolatedAsyncioTestCase):


### PR DESCRIPTION
Summary: Create get_cluster function, replace external usage in 2 files, create unittest.

Differential Revision: D36388753

