### PR TITLE
Delete kodiak since it won't be prioritized

### DIFF
--- a/fbpcp/decorator/error_handler.py
+++ b/fbpcp/decorator/error_handler.py
@@ -32,6 +32,6 @@ def error_handler(f: Callable) -> Callable:
         except OpenApiException as err:
             raise map_k8s_error(err) from None
         except Exception as err:
-            raise PcpError(err) from None
+            raise PcpError(err) from err
 
     return wrapper


### PR DESCRIPTION
Summary:
Easy come, easy go.
Some files here are contributing negatively to the test coverage metrics, and since it won't be prioritized for at least 6 months, it's not worth keeping around.

Differential Revision: D36505184

