### PR TITLE
Release fbpcp 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,10 @@ Release PCE validator and update onedocker dependencies
 
 ### Description of changes
 * Added support for skipping some validation steps in PCE Validator with the --skip-step CLI params
+
+## 0.2.8 -> 0.2.9
+### Types of changes
+* New feature (non-breaking change which adds functionality)
+
+### Description of changes
+* Add get_cluster function to OneDocker Service. Moves towards converting container_svc from public to private attribute.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.8",
+    version="0.2.9",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: Release fbpcp 0.3.0 with new get_cluster function in OneDocker Service

Differential Revision: D36723921

