### PR TITLE
Checksum Verification

### DIFF
--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import json
+import logging
 from typing import Dict, List, Union
 
 from fbpcp.service.storage import StorageService
@@ -20,12 +21,25 @@ DEFAULT_CHECKSUM_TYPES: List[ChecksumType] = [
     ChecksumType.BLAKE2B,
 ]
 
+# Package Info Dict Tags
+PACKAGE_NAME = "Package Name"
+PACKAGE_VERSION = "Package Version"
+PACKAGE_CHECKSUMS = "Checksums"
+
 
 class AttestationService:
     def __init__(self, storage_svc: StorageService, repository_path: str) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
         self.checksum_generator = LocalChecksumGenerator()
         self.storage_svc = storage_svc
         self.repository_path = repository_path
+
+    def _build_attestation_repository_path(
+        self,
+        package_name: str,
+        version: str,
+    ) -> str:
+        return f"{self.repository_path}{package_name}/{version}.json"
 
     def _format_package_info(
         self,
@@ -34,13 +48,9 @@ class AttestationService:
         checksums: Dict[str, str],
     ) -> Dict[str, Union[str, Dict[str, str]]]:
         package_info = {}
-
-        # General Package Info
-        package_info["Package Name"] = package_name
-        package_info["Package Version"] = version
-
-        # Checksum that were requested
-        package_info["Checksums"] = checksums
+        package_info[PACKAGE_NAME] = package_name
+        package_info[PACKAGE_VERSION] = version
+        package_info[PACKAGE_CHECKSUMS] = checksums
         return package_info
 
     def _upload_checksum(
@@ -53,7 +63,7 @@ class AttestationService:
         package_info = self._format_package_info(package_name, version, checksums)
 
         # Construct file information - (name and contents)
-        file_path = f"{self.repository_path}{package_name}/{version}.json"
+        file_path = self._build_attestation_repository_path(package_name, version)
         file_contents = json.dumps(package_info, indent=4)
 
         # upload contents to set repo path
@@ -65,15 +75,86 @@ class AttestationService:
         package_name: str,
         version: str,
     ) -> None:
+        """
+        This Function generates then uploads checksums for passed in local binary
+
+        Args:
+            binary_path:    Local file path pointing to the package
+            package_name:   Package Name to use when uploading file to checksum repository
+            version:        Package Version to relay while uploading file to checksum repository
+        """
         # Generates checksums
+        self.logger.info(f"Generating checksums for binary at {binary_path}")
         checksums: Dict[str, str] = self.checksum_generator.generate_checksums(
-            path_to_binary=binary_path,
+            binary_path=binary_path,
             checksum_algorithms=DEFAULT_CHECKSUM_TYPES,
         )
 
         # Upload checksums and package info to set repo path
+        self.logger.info(f"Uploading checksums for package {package_name}: {version}")
         self._upload_checksum(
             package_name=package_name,
             version=version,
             checksums=checksums,
         )
+
+    def verify_binary(
+        self,
+        binary_path: str,
+        package_name: str,
+        version: str,
+        checksum_algorithm: ChecksumType,
+    ) -> None:
+        """
+        This functions generates a checksum for a local file and then compares the generated value to what is stored in the checksum repository for the given package_name and version
+
+        Args:
+            binary_path:            Local file path pointing to the package
+            package_name:           Package Name to use when downlading the checksum file from checksum repository
+            version:                Package Version to relay while downloading the checksum file from checksum repository
+            checksum_algorithm:     Checksum algorithm that should be used while attesting local binary
+        """
+        # Build file path
+        file_path = self._build_attestation_repository_path(package_name, version)
+
+        if not self.storage_svc.file_exists(file_path):
+            self.logger.info(
+                f"Untracked package {package_name}: {version}. Skipping Attestion."
+            )
+            return None
+        # Retrieve file info and parse contents
+        file_contents = self.storage_svc.read(file_path)
+        package_info = json.loads(file_contents)
+
+        # Verify that file contents are for desired package
+        self.logger.info("Attesting correct package information was retrived")
+        if package_info[PACKAGE_NAME] != package_name:
+            raise ValueError(
+                f"Package Name {package_info[PACKAGE_NAME]} in file is different than passed in Name {package_name}"
+            )
+        if package_info[PACKAGE_VERSION] != version:
+            raise ValueError(
+                f"Package Version {package_info[PACKAGE_VERSION]} in file is different than passed in Version {version}"
+            )
+
+        # Process downloaded file and generate a local checksum
+        checksums: Dict[str, str] = self.checksum_generator.generate_checksums(
+            binary_path=binary_path,
+            checksum_algorithms=[checksum_algorithm],
+        )
+        package_checksums = package_info[PACKAGE_CHECKSUMS]
+
+        # Verify Checksum Details
+        self.logger.info("Attesting binary integrity")
+        if checksum_algorithm.name not in package_checksums:
+            raise ValueError(
+                f"Package Checksum Algorithms {package_checksums.keys()} does not contain passed in Checksum Algorithm {checksum_algorithm.name}"
+            )
+        if (
+            checksums[checksum_algorithm.name]
+            != package_checksums[checksum_algorithm.name]
+        ):
+            raise ValueError(
+                f"Package Checksum {package_checksums[checksum_algorithm.name]} for Checksum Algorithm {checksum_algorithm.name} does not match actual binary Checksum {checksums[checksum_algorithm.name]}"
+            )
+        self.logger.info("Binary successfully attested")

--- a/onedocker/service/checksum.py
+++ b/onedocker/service/checksum.py
@@ -35,7 +35,7 @@ class LocalChecksumGenerator:
 
     def generate_checksums(
         self,
-        path_to_binary: str,
+        binary_path: str,
         checksum_algorithms: List[ChecksumType],
     ) -> Dict[str, str]:
         """
@@ -43,8 +43,8 @@ class LocalChecksumGenerator:
             generate_checksums("/usr/bin/ls")
         """
         if len(checksum_algorithms) == 0:
-            raise ValueError("No hashing function(s) have been set")
-        encoded_contents = self._read_local_file(path_to_binary)
+            raise ValueError("No hashing function(s) have been provided")
+        encoded_contents = self._read_local_file(binary_path)
         checksums = {}
         for checksum_algorithm in checksum_algorithms:
             checksums.update(

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -16,8 +16,10 @@ from onedocker.service.checksum import LocalChecksumGenerator
 class TestAttestationService(unittest.TestCase):
     @patch.object(LocalChecksumGenerator, "generate_checksums")
     @patch.object(S3StorageService, "write")
-    def test_track_package_s3(
-        self, MockS3StorageServiceWrite, MockLocalChecksumGeneratorGenerateChecksum
+    def test_track_binary_s3(
+        self,
+        mockS3StorageServiceWrite,
+        mockLocalChecksumGeneratorGenerateChecksum,
     ):
         # Arrange
         repository_path = (
@@ -34,11 +36,12 @@ class TestAttestationService(unittest.TestCase):
         test_package_name = "ls"
         test_version = "latest"
 
-        MockLocalChecksumGeneratorGenerateChecksum.return_value = {
+        checksums = {
             "MD5": "valid_md5_checksum_goes_here",
             "SHA256": "valid_sha256_checksum_goes_here",
             "BLAKE2B": "valid_blake2b_checksum_goes_here",
         }
+        mockLocalChecksumGeneratorGenerateChecksum.return_value = checksums
 
         expected_file_contents = (
             "{\n"
@@ -61,11 +64,72 @@ class TestAttestationService(unittest.TestCase):
         )
 
         # Assert
-        MockLocalChecksumGeneratorGenerateChecksum.assert_called_once_with(
-            path_to_binary=test_path,
+        mockLocalChecksumGeneratorGenerateChecksum.assert_called_once_with(
+            binary_path=test_path,
             checksum_algorithms=algorithms,
         )
-        MockS3StorageServiceWrite.assert_called_once_with(
+        mockS3StorageServiceWrite.assert_called_once_with(
             expected_file_path,
             expected_file_contents,
+        )
+
+    @patch.object(LocalChecksumGenerator, "generate_checksums")
+    @patch.object(S3StorageService, "file_exists")
+    @patch.object(S3StorageService, "read")
+    def test_verify_binary_s3(
+        self,
+        mockS3StorageServiceRead,
+        mockS3StorageServiceFileExists,
+        mockLocalChecksumGeneratorGenerateChecksum,
+    ):
+        # Arrange
+        file_contents = (
+            "{\n"
+            + '    "Package Name": "ls",\n'
+            + '    "Package Version": "latest",\n'
+            + '    "Checksums": {\n'
+            + '        "MD5": "valid_md5_checksum_goes_here",\n'
+            + '        "SHA256": "valid_sha256_checksum_goes_here"\n'
+            + "    }\n}"
+        )
+        mockS3StorageServiceRead.return_value = file_contents
+        mockS3StorageServiceFileExists.return_value = True
+
+        checksums = {
+            "MD5": "valid_md5_checksum_goes_here",
+        }
+        mockLocalChecksumGeneratorGenerateChecksum.return_value = checksums
+
+        repository_path = (
+            "https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/"
+        )
+        attestation_service = AttestationService(
+            S3StorageService("us-west-2"),
+            repository_path,
+        )
+
+        test_path = "/usr/bin/ls"
+        test_package_name = "ls"
+        test_version = "latest"
+        test_algorithm = ChecksumType.MD5
+        expected_file_path = f"{repository_path}ls/latest.json"
+
+        # Act
+        attestation_service.verify_binary(
+            binary_path=test_path,
+            package_name=test_package_name,
+            version=test_version,
+            checksum_algorithm=test_algorithm,
+        )
+
+        # Assert
+        mockLocalChecksumGeneratorGenerateChecksum.assert_called_once_with(
+            binary_path=test_path,
+            checksum_algorithms=[test_algorithm],
+        )
+        mockS3StorageServiceRead.assert_called_once_with(
+            expected_file_path,
+        )
+        mockS3StorageServiceFileExists.assert_called_once_with(
+            expected_file_path,
         )


### PR DESCRIPTION
Summary:
# Context
Second half of attestation core
After checksums for file have been generated and uploaded there needs to be some method to ensure that it can easily be verified upon download

# This commit

Adds functionality to attestation service to retrieve stored checksums online and compare them to newly generated checksums along with other package data to ensure that the correct package was downloaded

> Old Summary
Takes passed in repositary path and ensures that the downloaded binary matches expected checksum

Differential Revision: D36710782

