### PR TITLE
Support using the AWS_SESSION_TOKEN in Storage Service (#316)

### DIFF
--- a/fbpcp/gateway/aws.py
+++ b/fbpcp/gateway/aws.py
@@ -17,6 +17,7 @@ class AWSGateway:
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
+        session_token: Optional[str] = None,
     ) -> None:
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.region = region
@@ -27,3 +28,6 @@ class AWSGateway:
 
         if access_key_data is not None:
             self.config["aws_secret_access_key"] = access_key_data
+
+        if session_token is not None:
+            self.config["aws_session_token"] = session_token

--- a/fbpcp/gateway/s3.py
+++ b/fbpcp/gateway/s3.py
@@ -28,8 +28,9 @@ class S3Gateway(AWSGateway):
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
+        session_token: Optional[str] = None,
     ) -> None:
-        super().__init__(region, access_key_id, access_key_data, config)
+        super().__init__(region, access_key_id, access_key_data, config, session_token)
         self.client: BaseClient = boto3.client(
             "s3", region_name=self.region, **self.config
         )

--- a/fbpcp/service/storage_s3.py
+++ b/fbpcp/service/storage_s3.py
@@ -25,8 +25,11 @@ class S3StorageService(StorageService):
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
+        session_token: Optional[str] = None,
     ) -> None:
-        self.s3_gateway = S3Gateway(region, access_key_id, access_key_data, config)
+        self.s3_gateway = S3Gateway(
+            region, access_key_id, access_key_data, config, session_token
+        )
 
     def read(self, filename: str) -> str:
         """Read a file data

--- a/tests/gateway/test_s3.py
+++ b/tests/gateway/test_s3.py
@@ -16,7 +16,9 @@ TEST_BUCKET = "test-bucket"
 TEST_FILE = "test-file"
 TEST_ACCESS_KEY_ID = "test-access-key-id"
 TEST_ACCESS_KEY_DATA = "test-access-key-data"
+TEST_SESSION_TOKEN = "test-session-token"
 TEST_S3_OPERATION = "head_object"
+TEST_DEFAULT_CONFIG = {}
 REGION = "us-west-1"
 
 
@@ -178,3 +180,43 @@ class TestS3Gateway(unittest.TestCase):
         ]
         self.assertEqual(key_list, expected_key_list)
         gw.client.get_paginator("list_object_v2").paginate.assert_called()
+
+    @patch("boto3.client")
+    def test_auth_keys(self, mock_boto_client):
+        gateway = S3Gateway(REGION, TEST_ACCESS_KEY_ID, TEST_ACCESS_KEY_DATA)
+        expected_config = {
+            "aws_access_key_id": TEST_ACCESS_KEY_ID,
+            "aws_secret_access_key": TEST_ACCESS_KEY_DATA,
+        }
+
+        mock_boto_client.assert_called_with(
+            "s3",
+            region_name=REGION,
+            aws_access_key_id=TEST_ACCESS_KEY_ID,
+            aws_secret_access_key=TEST_ACCESS_KEY_DATA,
+        )
+        self.assertEqual(gateway.config, expected_config)
+
+    @patch("boto3.client")
+    def test_session_auth_keys(self, mock_boto_client):
+        gateway = S3Gateway(
+            REGION,
+            TEST_ACCESS_KEY_ID,
+            TEST_ACCESS_KEY_DATA,
+            TEST_DEFAULT_CONFIG,
+            TEST_SESSION_TOKEN,
+        )
+        expected_config = {
+            "aws_access_key_id": TEST_ACCESS_KEY_ID,
+            "aws_secret_access_key": TEST_ACCESS_KEY_DATA,
+            "aws_session_token": TEST_SESSION_TOKEN,
+        }
+
+        mock_boto_client.assert_called_with(
+            "s3",
+            region_name=REGION,
+            aws_access_key_id=TEST_ACCESS_KEY_ID,
+            aws_secret_access_key=TEST_ACCESS_KEY_DATA,
+            aws_session_token=TEST_SESSION_TOKEN,
+        )
+        self.assertEqual(gateway.config, expected_config)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcp/pull/316

Please see context here https://docs.google.com/document/d/1b7PxYbmLed6_ou9n7HJcdcFcfJutRl_9q8A2KkF5IDM/edit (task 4 and 5).

TODO: add similar test for container service.

Reviewed By: zhuang-93

Differential Revision: D36666100

