### PR TITLE
Enable specifying the AWS_SESSION_TOKEN for the ContainerService

### DIFF
--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -39,8 +39,9 @@ class ECSGateway(AWSGateway, MetricsGetter):
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         metrics: Optional[MetricsEmitter] = None,
+        session_token: Optional[str] = None,
     ) -> None:
-        super().__init__(region, access_key_id, access_key_data, config)
+        super().__init__(region, access_key_id, access_key_data, config, session_token)
 
         self.client: BaseClient = self.create_ecs_client()
         self.metrics: Final[Optional[MetricsEmitter]] = metrics

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -30,13 +30,14 @@ class AWSContainerService(ContainerService):
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         metrics: Optional[MetricsEmitter] = None,
+        session_token: Optional[str] = None,
     ) -> None:
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.region = region
         self.cluster = cluster
         self.subnets = subnets
         self.ecs_gateway = ECSGateway(
-            region, access_key_id, access_key_data, config, metrics
+            region, access_key_id, access_key_data, config, metrics, session_token
         )
 
     def get_region(

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -20,6 +20,7 @@ TEST_INSTANCE_ID_DNE = "test-instance-id-dne"
 TEST_REGION = "us-west-2"
 TEST_KEY_ID = "test-key-id"
 TEST_KEY_DATA = "test-key-data"
+TEST_SESSION_TOKEN = "test-session-token"
 TEST_CLUSTER = "test-cluster"
 TEST_SUBNETS = ["test-subnet0", "test-subnet1"]
 TEST_IP_ADDRESS = "127.0.0.1"
@@ -206,3 +207,35 @@ class TestAWSContainerService(unittest.TestCase):
         # this is something we've seen in real runs
         with self.assertRaises(InvalidParameterError):
             self.container_svc.validate_container_definition("pl-task-fake-business:2#")
+
+    def test_auth_keys_with_session_token(self):
+        container_aws = AWSContainerService(
+            region=TEST_REGION,
+            cluster=TEST_CLUSTER,
+            subnets=TEST_SUBNETS,
+            access_key_id=TEST_KEY_ID,
+            access_key_data=TEST_KEY_DATA,
+            session_token=TEST_SESSION_TOKEN,
+        )
+        expected_config = {
+            "aws_access_key_id": TEST_KEY_ID,
+            "aws_secret_access_key": TEST_KEY_DATA,
+            "aws_session_token": TEST_SESSION_TOKEN,
+        }
+
+        self.assertEqual(container_aws.ecs_gateway.config, expected_config)
+
+    def test_auth_keys(self):
+        container_aws = AWSContainerService(
+            region=TEST_REGION,
+            cluster=TEST_CLUSTER,
+            subnets=TEST_SUBNETS,
+            access_key_id=TEST_KEY_ID,
+            access_key_data=TEST_KEY_DATA,
+        )
+        expected_config = {
+            "aws_access_key_id": TEST_KEY_ID,
+            "aws_secret_access_key": TEST_KEY_DATA,
+        }
+
+        self.assertEqual(container_aws.ecs_gateway.config, expected_config)


### PR DESCRIPTION
Differential Revision: D36993915

