### PR TITLE
Onedocker-Runner integration

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -1,5 +1,6 @@
-black==21.4b2
-ufmt==1.2
-usort==0.6.4
+black==22.3.0
+ufmt==2.0.0b2
+usort==1.0.2
+libcst==0.4.6
 flake8==3.9.0
 flake8-bugbear==21.3.2

--- a/onedocker/common/env.py
+++ b/onedocker/common/env.py
@@ -7,8 +7,14 @@
 # This is the repository path that OneDocker downloads binaries from
 ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"
 
+# This is the repository path that OneDocker downloads binary checksums from
+ONEDOCKER_CHECKSUM_REPOSITORY_PATH = "ONEDOCKER_CHECKSUM_REPOSITORY_PATH"
+
 # This is the local path that the binaries reside
 ONEDOCKER_EXE_PATH = "ONEDOCKER_EXE_PATH"
 
 # This is the path user specified to upload the core dump file to
 CORE_DUMP_REPOSITORY_PATH = "CORE_DUMP_REPOSITORY_PATH"
+
+# This is the type of checksum we want to compare when running program
+ONEDOCKER_CHECKSUM_TYPE = "ONEDOCKER_CHECKSUM_TYPE"

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -13,6 +13,7 @@ from docopt import docopt
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
 from fbpcp.error.pcp import InvalidParameterError
 from onedocker.common.core_dump_handler_aws import AWSCoreDumpHandler
+from onedocker.entity.checksum_type import ChecksumType
 from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
 from onedocker.script.runner.onedocker_runner import (
@@ -143,10 +144,10 @@ class TestOnedockerRunner(unittest.TestCase):
         self,
         mockOneDockerPackageRepositoryDownload,
         mockOneDockerChecksumRepositoryRead,
-        mockAttestationServiceVerifyBinary,
+        mockAttestationServiceAttestBinary,
     ):
         # Arrange
-        mockAttestationServiceVerifyBinary.return_value = None
+        mockAttestationServiceAttestBinary.return_value = None
         with patch.object(
             sys,
             "argv",
@@ -251,6 +252,157 @@ class TestOnedockerRunner(unittest.TestCase):
                 # Assert
                 self.assertEqual(cm.exception.code, 0)
 
+    @patch.object(AttestationService, "attest_binary")
+    @patch.object(OneDockerChecksumRepository, "read")
+    @patch.object(OneDockerPackageRepository, "download")
+    def test_main_checksum(
+        self,
+        mockOneDockerPackageRepositoryDownload,
+        mockOneDockerChecksumRepositoryRead,
+        mockAttestationServiceAttestBinary,
+    ):
+        # Arrange
+        mockAttestationServiceAttestBinary.return_value = None
+        mockOneDockerChecksumRepositoryRead.return_value = "checksum_info_goes_here"
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "onedocker-runner",
+                "ls",
+                "--version=latest",
+                "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
+                "--timeout=1200",
+                "--exe_path=/usr/bin/",
+                "--exe_args=-l",
+                "--checksum_repository_path=https://one-docker-checksum-repository-prod.s3.us-west-2.amazonaws.com/",
+                "--checksum_type=BLAKE2B",
+            ],
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                # Act
+                main()
+
+            # Assert
+            self.assertEqual(cm.exception.code, 0)
+            mockOneDockerPackageRepositoryDownload.assert_called_once_with(
+                "ls",
+                "latest",
+                "/usr/bin/ls",
+            )
+        mockAttestationServiceAttestBinary.assert_called_once_with(
+            binary_path="/usr/bin/ls",
+            package_name="ls",
+            version="latest",
+            formatted_checksum_info="checksum_info_goes_here",
+            checksum_algorithm=ChecksumType.BLAKE2B,
+        )
+        mockOneDockerChecksumRepositoryRead.assert_called_once_with(
+            "ls",
+            "latest",
+        )
+
+    @patch.object(AttestationService, "attest_binary")
+    @patch.object(OneDockerChecksumRepository, "read")
+    @patch.object(OneDockerPackageRepository, "download")
+    def test_main_checksum_default_type(
+        self,
+        mockOneDockerPackageRepositoryDownload,
+        mockOneDockerChecksumRepositoryRead,
+        mockAttestationServiceAttestBinary,
+    ):
+        # Arrange
+        mockAttestationServiceAttestBinary.return_value = None
+        mockOneDockerChecksumRepositoryRead.return_value = "checksum_info_goes_here"
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "onedocker-runner",
+                "ls",
+                "--version=latest",
+                "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
+                "--timeout=1200",
+                "--exe_path=/usr/bin/",
+                "--exe_args=-l",
+                "--checksum_repository_path=https://one-docker-checksum-repository-prod.s3.us-west-2.amazonaws.com/",
+            ],
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                # Act
+                main()
+
+            # Assert
+            self.assertEqual(cm.exception.code, 0)
+            mockOneDockerPackageRepositoryDownload.assert_called_once_with(
+                "ls",
+                "latest",
+                "/usr/bin/ls",
+            )
+        mockAttestationServiceAttestBinary.assert_called_once_with(
+            binary_path="/usr/bin/ls",
+            package_name="ls",
+            version="latest",
+            formatted_checksum_info="checksum_info_goes_here",
+            checksum_algorithm=ChecksumType.SHA256,
+        )
+        mockOneDockerChecksumRepositoryRead.assert_called_once_with(
+            "ls",
+            "latest",
+        )
+
+    @patch.object(AttestationService, "attest_binary")
+    @patch.object(OneDockerChecksumRepository, "read")
+    @patch.object(OneDockerPackageRepository, "download")
+    def test_main_checksum_env(
+        self,
+        mockOneDockerPackageRepositoryDownload,
+        mockOneDockerChecksumRepositoryRead,
+        mockAttestationServiceAttestBinary,
+    ):
+        # Arrange
+        mockAttestationServiceAttestBinary.return_value = None
+        mockOneDockerChecksumRepositoryRead.return_value = "checksum_info_goes_here"
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "onedocker-runner",
+                "ls",
+                "--version=latest",
+                "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
+                "--timeout=1200",
+                "--exe_path=/usr/bin/",
+                "--exe_args=-l",
+            ],
+        ):
+            with patch(
+                "os.getenv",
+                side_effect=lambda x: getenv(x),
+            ):
+                with self.assertRaises(SystemExit) as cm:
+                    # Act
+                    main()
+
+                # Assert
+                self.assertEqual(cm.exception.code, 0)
+            mockOneDockerPackageRepositoryDownload.assert_called_once_with(
+                "ls",
+                "latest",
+                "/usr/bin/ls",
+            )
+        mockAttestationServiceAttestBinary.assert_called_once_with(
+            binary_path="/usr/bin/ls",
+            package_name="ls",
+            version="latest",
+            formatted_checksum_info="checksum_info_goes_here",
+            checksum_algorithm=ChecksumType.MD5,
+        )
+        mockOneDockerChecksumRepositoryRead.assert_called_once_with(
+            "ls",
+            "latest",
+        )
+
     @patch("onedocker.script.runner.onedocker_runner.run_cmd")
     @patch.object(AWSCoreDumpHandler, "locate_core_dump_file")
     @patch.object(AWSCoreDumpHandler, "upload_core_dump_file")
@@ -296,5 +448,7 @@ def getenv(key):
         return "https://onedocker-checksum-repo.s3.us-west-2.amazonaws.com/checksums/"
     elif key == "CORE_DUMP_REPOSITORY_PATH":
         return "https://onedocker-core-dump.s3.us-west-2.amazonaws.com/checksums/"
+    elif key == "ONEDOCKER_CHECKSUM_TYPE":
+        return "MD5"
     else:
-        return None
+        raise KeyError from None


### PR DESCRIPTION
Summary:
# Context
All the tooling for attestation service should be complete, however, it still remain difficult for us to verify that the package downloaded is the correct one without manually scripting into attestation service

# This commit
Adds tooling integration into onedocker-runnner allowing it to ensure that all packages that want to be attested can be ensuring package validity. Goes over a few different manual tests with set failures to verify that certain errors are triggered correctly

> Old Summary:
Conclusion for Attestation integration into upload and download process, E2E verification on staging account that file can be fully tracked

Differential Revision: D36839896

