### PR TITLE
Update the cryptography version to match the internal version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,10 @@ Release PCE validator and update onedocker dependencies
 
 ### Description of changes
 * Add optional session_token field to the AWSContainerService and S3StorageService
+
+## 0.2.10 -> 0.2.11
+### Types of changes
+* Third-party library version updates
+
+### Description of changes
+* Update the cryptography version to match the internal version used.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "psutil==5.8.0",
     "click==7.1.2",
     "kubernetes==12.0.1",
-    "cryptography==36.0.2",
+    "cryptography==3.3.2",
 ]
 
 with open("README.md", encoding="utf-8") as f:
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.2.10",
+    version="0.2.11",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: This change rolls back the cryptography version to match the version we are using internally. Hopefully this reduces the chance of any feature conflicts and will allow the FBPCP library to be imported into the monorepo.

Differential Revision: D37078211

