### PR TITLE
Clarifying variable name

### DIFF
--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -95,11 +95,11 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--repository_path=local",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
             ],
         ):
             with self.assertRaises(SystemExit) as cm:
@@ -138,12 +138,12 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
                 "--timeout=1200",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
             ],
         ):
             with self.assertRaises(SystemExit) as cm:
@@ -154,9 +154,9 @@ class TestOnedockerRunner(unittest.TestCase):
             self.assertEqual(cm.exception.code, 0)
             # TODO: Update path once function is not hard coded
             MockOneDockerPackageRepositoryDownload.assert_called_once_with(
-                "ls",
+                "echo",
                 "latest",
-                "/usr/bin/ls",
+                "/usr/bin/echo",
             )
 
     @patch.object(OneDockerPackageRepository, "download")
@@ -172,10 +172,10 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
                 f"--cert_params={self.test_cert_params}"
                 # "--verbose",
             ],
@@ -189,9 +189,9 @@ class TestOnedockerRunner(unittest.TestCase):
             SelfSignedCertificateServiceGenerateCertificate.assert_called_once_with()
             # TODO: Update path once function is not hard coded
             MockOneDockerPackageRepositoryDownload.assert_called_once_with(
-                "ls",
+                "echo",
                 "latest",
-                "/usr/bin/ls",
+                "/usr/bin/echo",
             )
 
     def test_main_bad_cert(self):
@@ -208,7 +208,7 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--exe_path=/usr/bin/",
                 "--exe_args=measurement/private_measurement/pcp/oss/onedocker/tests/script/runner",

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -13,7 +13,10 @@ from docopt import docopt
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
 from fbpcp.error.pcp import InvalidParameterError
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
-from onedocker.script.runner.onedocker_runner import __doc__ as __onedocker_doc__, main
+from onedocker.script.runner.onedocker_runner import (
+    __doc__ as __onedocker_runner_doc__,
+    main,
+)
 from onedocker.service.certificate_self_signed import SelfSignedCertificateService
 
 
@@ -38,7 +41,7 @@ class TestOnedockerRunner(unittest.TestCase):
 
     def test_simple_args(self):
         # Arrange
-        doc = __onedocker_doc__
+        doc = __onedocker_runner_doc__
 
         # Act
         args = docopt(doc, ["test_package", "--version=1.0"])
@@ -55,7 +58,7 @@ class TestOnedockerRunner(unittest.TestCase):
 
     def test_complex_args(self):
         # Arrange
-        doc = __onedocker_doc__
+        doc = __onedocker_runner_doc__
 
         # Act
         args = docopt(


### PR DESCRIPTION
Summary:
# Context
tests make use of __onedocker_doc__, but with planned addition of tests to onedocker_cli this causes confusion
# This commit
replaces name with __onedocker_runner_doc__ for more clarity

Differential Revision: D37083777

