### PR TITLE
Cleaning up docs

### DIFF
--- a/onedocker/script/cli/onedocker_cli.py
+++ b/onedocker/script/cli/onedocker_cli.py
@@ -11,9 +11,9 @@ CLI for uploading an executable to one docker repo
 
 Usage:
     onedocker-cli upload --config=<config> --package_name=<package_name> --package_dir=<package_dir> [--version=<version> --enable_attestation] [options]
-    onedocker-cli test --package_name=<package_name> --cmd_args=<cmd_args> --config=<config> [--timeout=<timeout> --version=<version>][options]
-    onedocker-cli show --package_name=<package_name> --config=<config> [--version=<version>] [options]
-    onedocker-cli stop --container=<container_id> --config=<config> [options]
+    onedocker-cli test --config=<config> --package_name=<package_name> --cmd_args=<cmd_args> [--version=<version> --timeout=<timeout>][options]
+    onedocker-cli show --config=<config> --package_name=<package_name> [--version=<version>] [options]
+    onedocker-cli stop --config=<config> --container=<container_id> [options]
 
 Options:
     -h --help                Show this help

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -95,11 +95,11 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--repository_path=local",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
             ],
         ):
             with self.assertRaises(SystemExit) as cm:
@@ -138,12 +138,12 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
                 "--timeout=1200",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
             ],
         ):
             with self.assertRaises(SystemExit) as cm:
@@ -154,9 +154,9 @@ class TestOnedockerRunner(unittest.TestCase):
             self.assertEqual(cm.exception.code, 0)
             # TODO: Update path once function is not hard coded
             MockOneDockerPackageRepositoryDownload.assert_called_once_with(
-                "ls",
+                "echo",
                 "latest",
-                "/usr/bin/ls",
+                "/usr/bin/echo",
             )
 
     @patch.object(OneDockerPackageRepository, "download")
@@ -172,10 +172,10 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--exe_path=/usr/bin/",
-                "--exe_args=-l",
+                "--exe_args=test_message",
                 f"--cert_params={self.test_cert_params}"
                 # "--verbose",
             ],
@@ -189,9 +189,9 @@ class TestOnedockerRunner(unittest.TestCase):
             SelfSignedCertificateServiceGenerateCertificate.assert_called_once_with()
             # TODO: Update path once function is not hard coded
             MockOneDockerPackageRepositoryDownload.assert_called_once_with(
-                "ls",
+                "echo",
                 "latest",
-                "/usr/bin/ls",
+                "/usr/bin/echo",
             )
 
     def test_main_bad_cert(self):
@@ -208,7 +208,7 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "ls",
+                "echo",
                 "--version=latest",
                 "--exe_path=/usr/bin/",
                 "--exe_args=measurement/private_measurement/pcp/oss/onedocker/tests/script/runner",

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -13,7 +13,10 @@ from docopt import docopt
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
 from fbpcp.error.pcp import InvalidParameterError
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
-from onedocker.script.runner.onedocker_runner import __doc__ as __onedocker_doc__, main
+from onedocker.script.runner.onedocker_runner import (
+    __doc__ as __onedocker_runner_doc__,
+    main,
+)
 from onedocker.service.certificate_self_signed import SelfSignedCertificateService
 
 
@@ -38,7 +41,7 @@ class TestOnedockerRunner(unittest.TestCase):
 
     def test_simple_args(self):
         # Arrange
-        doc = __onedocker_doc__
+        doc = __onedocker_runner_doc__
 
         # Act
         args = docopt(doc, ["test_package", "--version=1.0"])
@@ -55,7 +58,7 @@ class TestOnedockerRunner(unittest.TestCase):
 
     def test_complex_args(self):
         # Arrange
-        doc = __onedocker_doc__
+        doc = __onedocker_runner_doc__
 
         # Act
         args = docopt(


### PR DESCRIPTION
Summary:
# Context
__doc__ for onedocker_cli has poor readibility due to garbled order
# This commit
Orders elements to enhance readibility

Differential Revision: D37084129

