### PR TITLE
Base integration into onedocker-runner

### DIFF
--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -71,6 +71,10 @@ def _set_resource_limit() -> None:
     resource.setrlimit(resource.RLIMIT_CORE, (core_size, core_size))
 
 
+def _build_executable_path(exe_path: str, exe_name: str) -> str:
+    return f"{exe_path}{exe_name}"
+
+
 def _prepare_executable(
     repository_path: str,
     exe_path: str,
@@ -85,8 +89,8 @@ def _prepare_executable(
 
     # grant execute permission to the downloaded executable file
     exe_name = _parse_package_name(package_name)
+    executable = _build_executable_path(exe_path, exe_name)
 
-    executable = f"{exe_path}{exe_name}"
     if not os.access(executable, os.X_OK):
         os.chmod(executable, os.stat(executable).st_mode | stat.S_IEXEC)
     return executable


### PR DESCRIPTION
Summary:
# Context
Have the function in script now should be able to interact with it if we want to, even if just dummy variables
Dont want to call when running on local files
# This commit
Adds params to support passing of value to function and ties to dummy hardcoded variables
Runs verification when file is not local and path is given

Differential Revision: D37229447

