### PR TITLE
Moving method globals inside classes

### DIFF
--- a/onedocker/repository/onedocker_package.py
+++ b/onedocker/repository/onedocker_package.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import List, Optional
+from typing import List
 
 from fbpcp.service.storage import StorageService
 from onedocker.entity.package_info import PackageInfo
@@ -33,20 +33,6 @@ class OneDockerPackageRepository:
     ) -> List[str]:
         package_parent_path = f"{self.repository_path}{package_name}/"
         return self.storage_svc.list_folders(package_parent_path)
-
-    def _read_contents(
-        self,
-        package_name: str,
-        version: str,
-        file_name: Optional[str] = None,
-    ) -> str:
-
-        if file_name is None:
-            file_path = self._build_package_path(package_name, version)
-        else:
-            file_path = f"{self.repository_path}{package_name}/{version}/{file_name}"
-
-        return self.storage_svc.read(file_path)
 
     def get_package_info(self, package_name: str, version: str) -> PackageInfo:
         package_path = self._build_package_path(package_name, version)

--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -14,20 +14,20 @@ from fbpcp.service.storage import StorageService
 from onedocker.entity.checksum_type import ChecksumType
 from onedocker.service.checksum import LocalChecksumGenerator
 
-# Default checksum types
-DEFAULT_CHECKSUM_TYPES: List[ChecksumType] = [
-    ChecksumType.MD5,
-    ChecksumType.SHA256,
-    ChecksumType.BLAKE2B,
-]
-
-# Package Info Dict Tags
-PACKAGE_NAME = "Package Name"
-PACKAGE_VERSION = "Package Version"
-PACKAGE_CHECKSUMS = "Checksums"
-
 
 class AttestationService:
+    # Default checksum types
+    DEFAULT_CHECKSUM_TYPES: List[ChecksumType] = [
+        ChecksumType.MD5,
+        ChecksumType.SHA256,
+        ChecksumType.BLAKE2B,
+    ]
+
+    # Package Info Dict Tags
+    PACKAGE_NAME = "Package Name"
+    PACKAGE_VERSION = "Package Version"
+    PACKAGE_CHECKSUMS = "Checksums"
+
     def __init__(self, storage_svc: StorageService, repository_path: str) -> None:
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.checksum_generator = LocalChecksumGenerator()
@@ -48,9 +48,9 @@ class AttestationService:
         checksums: Dict[str, str],
     ) -> Dict[str, Union[str, Dict[str, str]]]:
         package_info = {}
-        package_info[PACKAGE_NAME] = package_name
-        package_info[PACKAGE_VERSION] = version
-        package_info[PACKAGE_CHECKSUMS] = checksums
+        package_info[self.PACKAGE_NAME] = package_name
+        package_info[self.PACKAGE_VERSION] = version
+        package_info[self.PACKAGE_CHECKSUMS] = checksums
         return package_info
 
     def _upload_checksum(
@@ -87,7 +87,7 @@ class AttestationService:
         self.logger.info(f"Generating checksums for binary at {binary_path}")
         checksums: Dict[str, str] = self.checksum_generator.generate_checksums(
             binary_path=binary_path,
-            checksum_algorithms=DEFAULT_CHECKSUM_TYPES,
+            checksum_algorithms=self.DEFAULT_CHECKSUM_TYPES,
         )
 
         # Upload checksums and package info to set repo path
@@ -128,13 +128,13 @@ class AttestationService:
 
         # Verify that file contents are for desired package
         self.logger.info("Attesting correct package information was retrived")
-        if package_info[PACKAGE_NAME] != package_name:
+        if package_info[self.PACKAGE_NAME] != package_name:
             raise ValueError(
-                f"Package Name {package_info[PACKAGE_NAME]} in file is different than passed in Name {package_name}"
+                f"Package Name {package_info[self.PACKAGE_NAME]} in file is different than passed in Name {package_name}"
             )
-        if package_info[PACKAGE_VERSION] != version:
+        if package_info[self.PACKAGE_VERSION] != version:
             raise ValueError(
-                f"Package Version {package_info[PACKAGE_VERSION]} in file is different than passed in Version {version}"
+                f"Package Version {package_info[self.PACKAGE_VERSION]} in file is different than passed in Version {version}"
             )
 
         # Process downloaded file and generate a local checksum
@@ -142,7 +142,7 @@ class AttestationService:
             binary_path=binary_path,
             checksum_algorithms=[checksum_algorithm],
         )
-        package_checksums = package_info[PACKAGE_CHECKSUMS]
+        package_checksums = package_info[self.PACKAGE_CHECKSUMS]
 
         # Verify Checksum Details
         self.logger.info("Attesting binary integrity")

--- a/onedocker/tests/repository/test_repository.py
+++ b/onedocker/tests/repository/test_repository.py
@@ -12,11 +12,12 @@ from fbpcp.entity.file_information import FileInfo
 from onedocker.entity.package_info import PackageInfo
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
 
-TEST_PACKAGE_NAME = "project/exe_name"
-TEST_VERSION = "1.0"
-
 
 class TestOneDockerPackageRepository(unittest.TestCase):
+    TEST_PACKAGE_PATH = "project/exe_name"
+    TEST_PACKAGE_NAME = TEST_PACKAGE_PATH.split("/")[-1]
+    TEST_PACKAGE_VERSION = "1.0"
+
     @patch("fbpcp.service.storage_s3.S3StorageService")
     def setUp(self, MockStorageService):
         self.repository_path = "/abc/"
@@ -28,10 +29,12 @@ class TestOneDockerPackageRepository(unittest.TestCase):
         # Arrange
         source = "xyz"
 
-        expected_s3_dest = f"{self.repository_path}{TEST_PACKAGE_NAME}/{TEST_VERSION}/{TEST_PACKAGE_NAME.split('/')[-1]}"
+        expected_s3_dest = f"{self.repository_path}{self.TEST_PACKAGE_PATH}/{self.TEST_PACKAGE_VERSION}/{self.TEST_PACKAGE_NAME}"
 
         # Act
-        self.onedocker_repository.upload(TEST_PACKAGE_NAME, TEST_VERSION, source)
+        self.onedocker_repository.upload(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, source
+        )
 
         # Assert
         self.onedocker_repository.storage_svc.copy.assert_called_with(
@@ -43,10 +46,12 @@ class TestOneDockerPackageRepository(unittest.TestCase):
 
         destination = "xyz"
 
-        expected_s3_dest = f"{self.repository_path}{TEST_PACKAGE_NAME}/{TEST_VERSION}/{TEST_PACKAGE_NAME.split('/')[-1]}"
+        expected_s3_dest = f"{self.repository_path}{self.TEST_PACKAGE_PATH}/{self.TEST_PACKAGE_VERSION}/{self.TEST_PACKAGE_NAME}"
 
         # Act
-        self.onedocker_repository.download(TEST_PACKAGE_NAME, TEST_VERSION, destination)
+        self.onedocker_repository.download(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, destination
+        )
 
         # Assert
         self.onedocker_repository.storage_svc.copy.assert_called_with(
@@ -57,14 +62,16 @@ class TestOneDockerPackageRepository(unittest.TestCase):
         # Arrange
 
         test_list_folders = ["1.0/bar", "2.0/bar"]
-        package_parent_path = f"{self.repository_path}{TEST_PACKAGE_NAME}/"
+        package_parent_path = f"{self.repository_path}{self.TEST_PACKAGE_PATH}/"
 
         self.onedocker_repository.storage_svc.list_folders = MagicMock(
             return_value=test_list_folders
         )
 
         # Act
-        versions = self.onedocker_repository.get_package_versions(TEST_PACKAGE_NAME)
+        versions = self.onedocker_repository.get_package_versions(
+            self.TEST_PACKAGE_PATH
+        )
 
         # Assert
         self.onedocker_repository.storage_svc.list_folders.assert_called_with(
@@ -80,11 +87,13 @@ class TestOneDockerPackageRepository(unittest.TestCase):
 
         # Assert
         with self.assertRaises(ValueError):
-            self.onedocker_repository.get_package_info(TEST_PACKAGE_NAME, TEST_VERSION)
+            self.onedocker_repository.get_package_info(
+                self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
+            )
 
     def test_onedockerrepo_get_package_info(self):
         # Arrange
-        package_path = f"{self.repository_path}{TEST_PACKAGE_NAME}/{TEST_VERSION}/{TEST_PACKAGE_NAME.split('/')[-1]}"
+        package_path = f"{self.repository_path}{self.TEST_PACKAGE_PATH}/{self.TEST_PACKAGE_VERSION}/{self.TEST_PACKAGE_NAME}"
 
         self.onedocker_repository.storage_svc.file_exists = MagicMock(return_value=True)
 
@@ -99,15 +108,15 @@ class TestOneDockerPackageRepository(unittest.TestCase):
         )
 
         expected_package_info = PackageInfo(
-            package_name=TEST_PACKAGE_NAME,
-            version=TEST_VERSION,
+            package_name=self.TEST_PACKAGE_PATH,
+            version=self.TEST_PACKAGE_VERSION,
             last_modified=file_info.last_modified,
             package_size=file_info.file_size,
         )
 
         # Act
         package_info = self.onedocker_repository.get_package_info(
-            TEST_PACKAGE_NAME, TEST_VERSION
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
         )
 
         # Assert


### PR DESCRIPTION
Summary:
# Context
Lots of files exists with globals that are only used inside of the class instance

# This commit
moves these globals inside of the class to improve readability and implement them as class constants rather than file constants

Differential Revision: D37493883

