### PR TITLE
Renaming of verify_binary to attest_binary

### DIFF
--- a/onedocker/entity/checksum_info.py
+++ b/onedocker/entity/checksum_info.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class ChecksumInfo:
+    package_name: str
+    version: str
+    checksums: Dict[str, str]
+
+    def __eq__(self, other: ChecksumInfo) -> bool:
+        # Compare package details
+        if self.package_name != other.package_name:
+            return False
+        if self.version != other.version:
+            return False
+
+        # Common algorithms used between both instances
+        algorithms = set(self.checksums) & set(other.checksums)
+        if len(algorithms) == 0:
+            return False
+        # Compare hexdigests of matching checksum algorithms
+        for algorithm in algorithms:
+            if self.checksums[algorithm] != other.checksums[algorithm]:
+                return False
+        return True
+
+    def asdict(self) -> Dict[str, Any]:
+        return self.__dict__

--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -248,7 +248,7 @@ def _attest_executable(
     storage_svc = S3StorageService(S3Path(checksum_repository_path).region)
     attestation_service = AttestationService(storage_svc, checksum_repository_path)
 
-    attestation_service.verify_binary(
+    attestation_service.attest_binary(
         binary_path=binary_path,
         package_name=package_name,
         version=version,

--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -99,7 +99,7 @@ class AttestationService:
             checksum_info=checksum_info.asdict(),
         )
 
-    def verify_binary(
+    def attest_binary(
         self,
         binary_path: str,
         package_name: str,

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -133,7 +133,7 @@ class TestOnedockerRunner(unittest.TestCase):
             # Assert
             self.assertEqual(cm.exception.code, 1)
 
-    @patch.object(AttestationService, "verify_binary")
+    @patch.object(AttestationService, "attest_binary")
     @patch.object(OneDockerPackageRepository, "download")
     def test_main(
         self,

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -9,6 +9,7 @@ from json import dumps
 from unittest.mock import MagicMock, patch
 
 from fbpcp.service.storage_s3 import S3StorageService
+from onedocker.entity.checksum_info import ChecksumInfo
 from onedocker.entity.checksum_type import ChecksumType
 from onedocker.service.attestation import AttestationService
 
@@ -36,11 +37,11 @@ class TestAttestationService(unittest.TestCase):
             self.repository_path,
         )
         self.file_contents = dumps(
-            self.attestation_service._format_package_info(
+            ChecksumInfo(
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
                 checksums=self.checksums,
-            ),
+            ).asdict(),
             indent=4,
         )
 
@@ -169,7 +170,10 @@ class TestAttestationService(unittest.TestCase):
             )
 
         # Assert
-        assert not self.attestation_service.checksum_generator.generate_checksums.called
+        self.attestation_service.checksum_generator.generate_checksums.assert_called_once_with(
+            binary_path=self.test_package["binary_path"],
+            checksum_algorithms=[test_algorithm],
+        )
         self.attestation_service.storage_svc.read.assert_called_once_with(
             self.test_package["checksum_path"],
         )
@@ -201,7 +205,10 @@ class TestAttestationService(unittest.TestCase):
             )
 
         # Assert
-        assert not self.attestation_service.checksum_generator.generate_checksums.called
+        self.attestation_service.checksum_generator.generate_checksums.assert_called_once_with(
+            binary_path=self.test_package["binary_path"],
+            checksum_algorithms=[test_algorithm],
+        )
         self.attestation_service.storage_svc.read.assert_called_once_with(
             self.test_package["checksum_path"],
         )

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -76,7 +76,7 @@ class TestAttestationService(unittest.TestCase):
             self.file_contents,
         )
 
-    def test_verify_binary_s3(
+    def test_attest_binary_s3(
         self,
     ):
         # Arrange
@@ -88,7 +88,7 @@ class TestAttestationService(unittest.TestCase):
         }
 
         # Act
-        self.attestation_service.verify_binary(
+        self.attestation_service.attest_binary(
             binary_path=self.test_package["binary_path"],
             package_name=self.test_package["name"],
             version=self.test_package["version"],
@@ -107,7 +107,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_nonmatching_algorithm(
+    def test_attest_binary_s3_nonmatching_algorithm(
         self,
     ):
         # Arrange
@@ -127,7 +127,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -146,7 +146,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_name(
+    def test_attest_binary_s3_bad_name(
         self,
     ):
         # Arrange
@@ -162,7 +162,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -181,7 +181,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_version(
+    def test_attest_binary_s3_bad_version(
         self,
     ):
         # Arrange
@@ -197,7 +197,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -216,7 +216,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_checksum(
+    def test_attest_binary_s3_bad_checksum(
         self,
     ):
         # Arrange
@@ -235,7 +235,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],


### PR DESCRIPTION
Summary:
# Context
attestation should attest a binary not verify it
# This commit
renames function to follow logic

Differential Revision: D37623838

