### PR TITLE
Adding and implementing Attestation Error

### DIFF
--- a/onedocker/entity/attestation_error.py
+++ b/onedocker/entity/attestation_error.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class AttestationError(Exception):
+    """Package Info for downloaded binary and uploaded data differed"""
+
+    pass

--- a/onedocker/entity/checksum_info.py
+++ b/onedocker/entity/checksum_info.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class ChecksumInfo:
+    package_name: str
+    version: str
+    checksums: Dict[str, str]
+
+    def __eq__(self, other: ChecksumInfo) -> bool:
+        # Compare package details
+        if self.package_name != other.package_name:
+            return False
+        if self.version != other.version:
+            return False
+
+        # Common algorithms used between both instances
+        algorithms = set(self.checksums) & set(other.checksums)
+        if len(algorithms) == 0:
+            return False
+        # Compare hexdigests of matching checksum algorithms
+        for algorithm in algorithms:
+            if self.checksums[algorithm] != other.checksums[algorithm]:
+                return False
+        return True
+
+    def asdict(self) -> Dict[str, Any]:
+        return self.__dict__

--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -248,7 +248,7 @@ def _attest_executable(
     storage_svc = S3StorageService(S3Path(checksum_repository_path).region)
     attestation_service = AttestationService(storage_svc, checksum_repository_path)
 
-    attestation_service.verify_binary(
+    attestation_service.attest_binary(
         binary_path=binary_path,
         package_name=package_name,
         version=version,

--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -99,7 +99,7 @@ class AttestationService:
             checksum_info=checksum_info.asdict(),
         )
 
-    def verify_binary(
+    def attest_binary(
         self,
         binary_path: str,
         package_name: str,

--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any, Dict, List
 
 from fbpcp.service.storage import StorageService
+from onedocker.entity.attestation_error import AttestationError
 from onedocker.entity.checksum_info import ChecksumInfo
 from onedocker.entity.checksum_type import ChecksumType
 from onedocker.service.checksum import LocalChecksumGenerator
@@ -138,7 +139,7 @@ class AttestationService:
         )
 
         if checksum_info != package_checksum_info:
-            raise ValueError(
+            raise AttestationError(
                 "Downloaded binaries checksum information differs from uploaded package's checksum information"
             )
         self.logger.info("Binary successfully attested")

--- a/onedocker/tests/entity/test_checksum_info.py
+++ b/onedocker/tests/entity/test_checksum_info.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from onedocker.entity.checksum_info import ChecksumInfo
+
+
+class TestChecksumInfo(unittest.TestCase):
+    TEST_PACKAGE_NAME = "ls"
+    TEST_VERSION = "latest"
+    TEST_CHECKSUMS = {
+        "MD5": "valid_md5_goes_here",
+        "SHA256": "valid_sha256_goes_here",
+        "BLAKE2B": "valid_blake2b_goes_here",
+    }
+
+    def setUp(self):
+        self.good_checksum = ChecksumInfo(
+            package_name=self.TEST_PACKAGE_NAME,
+            version=self.TEST_VERSION,
+            checksums=self.TEST_CHECKSUMS,
+        )
+
+    def test_eq_self(self):
+        self.assertEqual(self.good_checksum, self.good_checksum)
+
+    def test_eq_dict(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": self.TEST_VERSION,
+            "checksums": self.TEST_CHECKSUMS,
+        }
+
+        self.assertEqual(self.good_checksum, ChecksumInfo(**checksum_info))
+
+    def test_eq_asdict(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": self.TEST_VERSION,
+            "checksums": self.TEST_CHECKSUMS,
+        }
+
+        self.assertDictEqual(self.good_checksum.asdict(), checksum_info)
+
+    def test_eq_package_name(self):
+        checksum_info = {
+            "package_name": "bad_package_name",
+            "version": self.TEST_VERSION,
+            "checksums": self.TEST_CHECKSUMS,
+        }
+
+        self.assertNotEqual(self.good_checksum, ChecksumInfo(**checksum_info))
+
+    def test_eq_version(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": "bad_version",
+            "checksums": self.TEST_CHECKSUMS,
+        }
+
+        self.assertNotEqual(self.good_checksum, ChecksumInfo(**checksum_info))
+
+    def test_eq_checksum(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": self.TEST_VERSION,
+            "checksums": {
+                "MD5": "invalid_md5_goes_here",
+                "SHA256": "valid_sha256_goes_here",
+                "BLAKE2B": "valid_blake2b_goes_here",
+            },
+        }
+
+        self.assertNotEqual(self.good_checksum, ChecksumInfo(**checksum_info))
+
+    def test_eq_no_matching_checksum(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": self.TEST_VERSION,
+            "checksums": {
+                "NOT_MD5": "valid_not_md5_goes_here",
+                "NOT_SHA256": "valid_not_sha256_goes_here",
+                "NOT_BLAKE2B": "valid_not_blake2b_goes_here",
+            },
+        }
+
+        self.assertNotEqual(self.good_checksum, ChecksumInfo(**checksum_info))
+
+    def test_eq_checksum_nonmatching_amount(self):
+        checksum_info = {
+            "package_name": self.TEST_PACKAGE_NAME,
+            "version": self.TEST_VERSION,
+            "checksums": {
+                "SHA256": "valid_sha256_goes_here",
+                "BLAKE2B": "valid_blake2b_goes_here",
+            },
+        }
+
+        self.assertEqual(self.good_checksum, ChecksumInfo(**checksum_info))

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -133,7 +133,7 @@ class TestOnedockerRunner(unittest.TestCase):
             # Assert
             self.assertEqual(cm.exception.code, 1)
 
-    @patch.object(AttestationService, "verify_binary")
+    @patch.object(AttestationService, "attest_binary")
     @patch.object(OneDockerPackageRepository, "download")
     def test_main(
         self,

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -9,6 +9,7 @@ from json import dumps
 from unittest.mock import MagicMock, patch
 
 from fbpcp.service.storage_s3 import S3StorageService
+from onedocker.entity.checksum_info import ChecksumInfo
 from onedocker.entity.checksum_type import ChecksumType
 from onedocker.service.attestation import AttestationService
 
@@ -36,11 +37,11 @@ class TestAttestationService(unittest.TestCase):
             self.repository_path,
         )
         self.file_contents = dumps(
-            self.attestation_service._format_package_info(
+            ChecksumInfo(
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
                 checksums=self.checksums,
-            ),
+            ).asdict(),
             indent=4,
         )
 
@@ -169,7 +170,10 @@ class TestAttestationService(unittest.TestCase):
             )
 
         # Assert
-        assert not self.attestation_service.checksum_generator.generate_checksums.called
+        self.attestation_service.checksum_generator.generate_checksums.assert_called_once_with(
+            binary_path=self.test_package["binary_path"],
+            checksum_algorithms=[test_algorithm],
+        )
         self.attestation_service.storage_svc.read.assert_called_once_with(
             self.test_package["checksum_path"],
         )
@@ -201,7 +205,10 @@ class TestAttestationService(unittest.TestCase):
             )
 
         # Assert
-        assert not self.attestation_service.checksum_generator.generate_checksums.called
+        self.attestation_service.checksum_generator.generate_checksums.assert_called_once_with(
+            binary_path=self.test_package["binary_path"],
+            checksum_algorithms=[test_algorithm],
+        )
         self.attestation_service.storage_svc.read.assert_called_once_with(
             self.test_package["checksum_path"],
         )

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -9,6 +9,7 @@ from json import dumps
 from unittest.mock import MagicMock, patch
 
 from fbpcp.service.storage_s3 import S3StorageService
+from onedocker.entity.attestation_error import AttestationError
 from onedocker.entity.checksum_info import ChecksumInfo
 from onedocker.entity.checksum_type import ChecksumType
 from onedocker.service.attestation import AttestationService
@@ -126,7 +127,7 @@ class TestAttestationService(unittest.TestCase):
         }
 
         # Act
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttestationError):
             self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
@@ -161,7 +162,7 @@ class TestAttestationService(unittest.TestCase):
         test_algorithm = ChecksumType(checksum_key)
 
         # Act
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttestationError):
             self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
@@ -196,7 +197,7 @@ class TestAttestationService(unittest.TestCase):
         test_algorithm = ChecksumType(checksum_key)
 
         # Act
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttestationError):
             self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
@@ -234,7 +235,7 @@ class TestAttestationService(unittest.TestCase):
         }
 
         # Act
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttestationError):
             self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -76,7 +76,7 @@ class TestAttestationService(unittest.TestCase):
             self.file_contents,
         )
 
-    def test_verify_binary_s3(
+    def test_attest_binary_s3(
         self,
     ):
         # Arrange
@@ -88,7 +88,7 @@ class TestAttestationService(unittest.TestCase):
         }
 
         # Act
-        self.attestation_service.verify_binary(
+        self.attestation_service.attest_binary(
             binary_path=self.test_package["binary_path"],
             package_name=self.test_package["name"],
             version=self.test_package["version"],
@@ -107,7 +107,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_nonmatching_algorithm(
+    def test_attest_binary_s3_nonmatching_algorithm(
         self,
     ):
         # Arrange
@@ -127,7 +127,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -146,7 +146,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_name(
+    def test_attest_binary_s3_bad_name(
         self,
     ):
         # Arrange
@@ -162,7 +162,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -181,7 +181,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_version(
+    def test_attest_binary_s3_bad_version(
         self,
     ):
         # Arrange
@@ -197,7 +197,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],
@@ -216,7 +216,7 @@ class TestAttestationService(unittest.TestCase):
             self.test_package["checksum_path"],
         )
 
-    def test_verify_binary_s3_bad_checksum(
+    def test_attest_binary_s3_bad_checksum(
         self,
     ):
         # Arrange
@@ -235,7 +235,7 @@ class TestAttestationService(unittest.TestCase):
 
         # Act
         with self.assertRaises(ValueError):
-            self.attestation_service.verify_binary(
+            self.attestation_service.attest_binary(
                 binary_path=self.test_package["binary_path"],
                 package_name=self.test_package["name"],
                 version=self.test_package["version"],


### PR DESCRIPTION
Summary: Error needs to be more specific when attestation fails and this error imediatly alerts us that an error is attestation specific rather than something else

Reviewed By: ziqih

Differential Revision: D37524648

