### PR TITLE
Adding function to handle uploading of checksums

### DIFF
--- a/onedocker/repository/onedocker_checksum.py
+++ b/onedocker/repository/onedocker_checksum.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.service.storage import StorageService
+
+
+class OneDockerChecksumRepository:
+    def __init__(
+        self, storage_svc: StorageService, checksum_repository_path: str
+    ) -> None:
+        self.storage_svc = storage_svc
+        self.checksum_repository_path = checksum_repository_path
+
+    def _build_checksum_path(self, package_name: str, version: str) -> str:
+        if not self.checksum_repository_path:
+            raise ValueError(
+                "Checksum Repository Path not set. Unable to attest Package"
+            )
+        return f"{self.checksum_repository_path}{package_name}/{version}/{package_name.split('/')[-1]}.json"
+
+    def write(self, package_name: str, version: str, checksum_data: str) -> None:
+        package_path = self._build_checksum_path(
+            package_name=package_name, version=version
+        )
+        self.storage_svc.write(filename=package_path, data=checksum_data)

--- a/onedocker/tests/repository/test_onedocker_checksum.py
+++ b/onedocker/tests/repository/test_onedocker_checksum.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
+
+
+class TestOneDockerChecksumRepository(unittest.TestCase):
+    TEST_PACKAGE_NAME = "project/exe_name"
+    TEST_PACKAGE_VERSION = "1.0"
+
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def setUp(self, MockStorageService):
+        self.checksum_repository_path = "/abc/"
+        self.onedocker_checksum = OneDockerChecksumRepository(
+            MockStorageService, self.checksum_repository_path
+        )
+        self.expected_s3_dest = f"{self.checksum_repository_path}{self.TEST_PACKAGE_NAME}/{self.TEST_PACKAGE_VERSION}/{self.TEST_PACKAGE_NAME.split('/')[-1]}.json"
+
+    def test_onedockerrepo_write(self):
+        # Arrange
+        checksum_data = "xyz"
+
+        # Act
+        self.onedocker_checksum.write(
+            package_name=self.TEST_PACKAGE_NAME,
+            version=self.TEST_PACKAGE_VERSION,
+            checksum_data=checksum_data,
+        )
+
+        # Assert
+        self.onedocker_checksum.storage_svc.write.assert_called_with(
+            filename=self.expected_s3_dest, data=checksum_data
+        )
+
+    def test_onedockerrepo_write_no_checksum_path(self):
+        # Arrange
+        checksum_data = "xyz"
+
+        onedocker_checksum = OneDockerChecksumRepository(MagicMock(), "")
+
+        # Act & Assert
+        with self.assertRaises(ValueError):
+            onedocker_checksum.write(
+                package_name=self.TEST_PACKAGE_NAME,
+                version=self.TEST_PACKAGE_VERSION,
+                checksum_data=checksum_data,
+            )


### PR DESCRIPTION
Summary:
# Context
Want to move s3 i/o out of attestation service.
# This commit
Creates tooling that would enable move to happen, and changes checksum path to follow styling of repository path for simplicity

Reviewed By: ziqih

Differential Revision: D37524841

