### PR TITLE
Moving checksum upload from attestation to ODCR

### DIFF
--- a/onedocker/repository/onedocker_checksum.py
+++ b/onedocker/repository/onedocker_checksum.py
@@ -23,8 +23,26 @@ class OneDockerChecksumRepository:
             )
         return f"{self.checksum_repository_path}{package_name}/{version}/{package_name.split('/')[-1]}.json"
 
+    def _file_exists(self, package_name: str, version: str) -> bool:
+        package_path = self._build_checksum_path(
+            package_name=package_name, version=version
+        )
+        return self.storage_svc.file_exists(package_path)
+
     def write(self, package_name: str, version: str, checksum_data: str) -> None:
         package_path = self._build_checksum_path(
             package_name=package_name, version=version
         )
         self.storage_svc.write(filename=package_path, data=checksum_data)
+
+    def read(self, package_name: str, version: str) -> str:
+        package_path = self._build_checksum_path(
+            package_name=package_name, version=version
+        )
+
+        if not self._file_exists(package_name, version):
+            raise FileNotFoundError(
+                f"Cant find checksum file for package {package_name}, version {version}"
+            )
+
+        return self.storage_svc.read(filename=package_path)

--- a/onedocker/repository/onedocker_checksum.py
+++ b/onedocker/repository/onedocker_checksum.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.service.storage import StorageService
+
+
+class OneDockerChecksumRepository:
+    def __init__(
+        self, storage_svc: StorageService, checksum_repository_path: str
+    ) -> None:
+        self.storage_svc = storage_svc
+        self.checksum_repository_path = checksum_repository_path
+
+    def _build_checksum_path(self, package_name: str, version: str) -> str:
+        if not self.checksum_repository_path:
+            raise ValueError(
+                "Checksum Repository Path not set. Unable to attest Package"
+            )
+        return f"{self.checksum_repository_path}{package_name}/{version}/{package_name.split('/')[-1]}.json"
+
+    def write(self, package_name: str, version: str, checksum_data: str) -> None:
+        package_path = self._build_checksum_path(
+            package_name=package_name, version=version
+        )
+        self.storage_svc.write(filename=package_path, data=checksum_data)

--- a/onedocker/service/attestation.py
+++ b/onedocker/service/attestation.py
@@ -8,7 +8,7 @@
 
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Dict, List, Optional
 
 from fbpcp.service.storage import StorageService
 from onedocker.entity.attestation_error import AttestationError
@@ -25,11 +25,16 @@ class AttestationService:
         ChecksumType.BLAKE2B,
     ]
 
-    def __init__(self, storage_svc: StorageService, repository_path: str) -> None:
+    def __init__(
+        self,
+        storage_svc: Optional[StorageService] = None,
+        repository_path: str = "",
+    ) -> None:
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.checksum_generator = LocalChecksumGenerator()
-        self.storage_svc = storage_svc
-        self.repository_path = repository_path
+        if storage_svc is not None:
+            self.storage_svc: StorageService = storage_svc
+        self.repository_path: str = repository_path
 
     def _build_attestation_repository_path(
         self,
@@ -56,26 +61,12 @@ class AttestationService:
             checksums=checksums,
         )
 
-    def _upload_checksum(
-        self,
-        package_name: str,
-        version: str,
-        checksum_info: Dict[str, Any],
-    ) -> None:
-
-        # Construct file information - (name and contents)
-        file_path = self._build_attestation_repository_path(package_name, version)
-        file_contents = json.dumps(checksum_info, indent=4)
-
-        # upload contents to set repo path
-        self.storage_svc.write(file_path, file_contents)
-
     def track_binary(
         self,
         binary_path: str,
         package_name: str,
         version: str,
-    ) -> None:
+    ) -> str:
         """
         This Function generates then uploads checksums for passed in local binary
 
@@ -83,6 +74,9 @@ class AttestationService:
             binary_path:        Local file path pointing to the package
             package_name:       Package Name to use when uploading file to checksum repository
             version:    Package Version to relay while uploading file to checksum repository
+
+        Returns:
+            formated_checksum_info:  A JSON formated file that contains all the checksum data for a file
         """
         # Generates checksums
         self.logger.info(f"Generating checksums for binary at {binary_path}")
@@ -92,13 +86,7 @@ class AttestationService:
             binary_path=binary_path,
         )
 
-        # Upload checksums and package info to set repo path
-        self.logger.info(f"Uploading checksums for package {package_name}: {version}")
-        self._upload_checksum(
-            package_name=package_name,
-            version=version,
-            checksum_info=checksum_info.asdict(),
-        )
+        return json.dumps(checksum_info.asdict(), indent=4)
 
     def attest_binary(
         self,

--- a/onedocker/tests/repository/test_onedocker_checksum.py
+++ b/onedocker/tests/repository/test_onedocker_checksum.py
@@ -52,3 +52,43 @@ class TestOneDockerChecksumRepository(unittest.TestCase):
                 version=self.TEST_PACKAGE_VERSION,
                 checksum_data=checksum_data,
             )
+
+    def test_onedockerrepo_read(self):
+        # Arrange
+        checksum_data = "xyz"
+
+        self.onedocker_checksum.storage_svc.read = MagicMock(return_value=checksum_data)
+
+        # Act
+        actual_checksum_data = self.onedocker_checksum.read(
+            package_name=self.TEST_PACKAGE_NAME,
+            version=self.TEST_PACKAGE_VERSION,
+        )
+
+        # Assert
+        self.onedocker_checksum.storage_svc.read.assert_called_with(
+            filename=self.expected_s3_dest
+        )
+        self.assertEqual(checksum_data, actual_checksum_data)
+
+    def test_onedockerrepo_read_no_checksum_path(self):
+        # Arrange
+        onedocker_checksum = OneDockerChecksumRepository(MagicMock(), "")
+
+        # Act & Assert
+        with self.assertRaises(ValueError):
+            onedocker_checksum.read(
+                package_name=self.TEST_PACKAGE_NAME,
+                version=self.TEST_PACKAGE_VERSION,
+            )
+
+    def test_onedockerrepo_read_no_file_exist(self):
+        # Arrange
+        self.onedocker_checksum.storage_svc.file_exists = MagicMock(return_value=False)
+
+        # Act & Assert
+        with self.assertRaises(FileNotFoundError):
+            self.onedocker_checksum.read(
+                package_name=self.TEST_PACKAGE_NAME,
+                version=self.TEST_PACKAGE_VERSION,
+            )

--- a/onedocker/tests/repository/test_onedocker_checksum.py
+++ b/onedocker/tests/repository/test_onedocker_checksum.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
+
+
+class TestOneDockerChecksumRepository(unittest.TestCase):
+    TEST_PACKAGE_NAME = "project/exe_name"
+    TEST_PACKAGE_VERSION = "1.0"
+
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def setUp(self, MockStorageService):
+        self.checksum_repository_path = "/abc/"
+        self.onedocker_checksum = OneDockerChecksumRepository(
+            MockStorageService, self.checksum_repository_path
+        )
+        self.expected_s3_dest = f"{self.checksum_repository_path}{self.TEST_PACKAGE_NAME}/{self.TEST_PACKAGE_VERSION}/{self.TEST_PACKAGE_NAME.split('/')[-1]}.json"
+
+    def test_onedockerrepo_write(self):
+        # Arrange
+        checksum_data = "xyz"
+
+        # Act
+        self.onedocker_checksum.write(
+            package_name=self.TEST_PACKAGE_NAME,
+            version=self.TEST_PACKAGE_VERSION,
+            checksum_data=checksum_data,
+        )
+
+        # Assert
+        self.onedocker_checksum.storage_svc.write.assert_called_with(
+            filename=self.expected_s3_dest, data=checksum_data
+        )
+
+    def test_onedockerrepo_write_no_checksum_path(self):
+        # Arrange
+        checksum_data = "xyz"
+
+        onedocker_checksum = OneDockerChecksumRepository(MagicMock(), "")
+
+        # Act & Assert
+        with self.assertRaises(ValueError):
+            onedocker_checksum.write(
+                package_name=self.TEST_PACKAGE_NAME,
+                version=self.TEST_PACKAGE_VERSION,
+                checksum_data=checksum_data,
+            )

--- a/onedocker/tests/script/cli/test_onedocker_cli.py
+++ b/onedocker/tests/script/cli/test_onedocker_cli.py
@@ -17,6 +17,7 @@ from fbpcp.service.log_cloudwatch import CloudWatchLogService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.util import yaml as util_yaml
 from onedocker.entity.package_info import PackageInfo
+from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
 from onedocker.script.cli.onedocker_cli import __doc__ as __onedocker_cli_doc__, main
 from onedocker.service.attestation import AttestationService
@@ -57,6 +58,7 @@ class TestOnedockerCli(unittest.TestCase):
         self.timeout = "100"
         self.cmd_args = "-h"
         self.container = "secret_container"
+        self.checksums = "formated_checksums_go_here"
 
         self.package_info = PackageInfo(
             package_name=self.package_name,
@@ -101,6 +103,11 @@ class TestOnedockerCli(unittest.TestCase):
             "upload",
             MagicMock(return_value=None),
         ).start()
+        self.mockODCRWrite = patch.object(
+            OneDockerChecksumRepository,
+            "write",
+            MagicMock(return_value=None),
+        ).start()
         self.mockODPRGetPackageVersions = patch.object(
             OneDockerPackageRepository,
             "get_package_versions",
@@ -115,7 +122,7 @@ class TestOnedockerCli(unittest.TestCase):
         self.mockAttestationServiceTrackBinary = patch.object(
             AttestationService,
             "track_binary",
-            MagicMock(),
+            MagicMock(return_value=self.checksums),
         ).start()
 
         self.mockContainerService = patch.object(
@@ -286,11 +293,18 @@ class TestOnedockerCli(unittest.TestCase):
 
         # Assert
         self.mockYamlLoad.assert_called_once()
+        self.mockODCRWrite.assert_called_once_with(
+            package_name=self.package_name,
+            version=self.version,
+            checksum_data=self.checksums,
+        )
         self.mockODPRUpload.assert_called_once_with(
             self.package_name, self.version, self.package_dir
         )
         self.mockAttestationServiceTrackBinary.assert_called_once_with(
-            self.package_dir, self.package_name, self.version
+            binary_path=self.package_dir,
+            package_name=self.package_name,
+            version=self.version,
         )
 
     @patch.object(CloudWatchLogService, "get_log_path")

--- a/onedocker/tests/service/test_attestation.py
+++ b/onedocker/tests/service/test_attestation.py
@@ -6,7 +6,7 @@
 
 import unittest
 from json import dumps
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from fbpcp.service.storage_s3 import S3StorageService
 from onedocker.entity.attestation_error import AttestationError
@@ -55,13 +55,9 @@ class TestAttestationService(unittest.TestCase):
         )
         self.attestation_service.storage_svc.file_exists = MagicMock(return_value=True)
 
-    @patch.object(S3StorageService, "write")
-    def test_track_binary_s3(
-        self,
-        mockS3StorageServiceWrite,
-    ):
+    def test_track_binary_s3(self):
         # Arrange & Act
-        self.attestation_service.track_binary(
+        formated_checksums = self.attestation_service.track_binary(
             binary_path=self.test_package["binary_path"],
             package_name=self.test_package["name"],
             version=self.test_package["version"],
@@ -72,10 +68,7 @@ class TestAttestationService(unittest.TestCase):
             binary_path=self.test_package["binary_path"],
             checksum_algorithms=self.algorithms,
         )
-        mockS3StorageServiceWrite.assert_called_once_with(
-            self.test_package["checksum_path"],
-            self.file_contents,
-        )
+        self.assertEqual(formated_checksums, self.file_contents)
 
     def test_attest_binary_s3(
         self,


### PR DESCRIPTION
Summary:
# Context
We added functionality to upload checksums to ODPR, but dont use it atm.
# This commit
Removes the uploading from AttestationService and puts it into ODPR.

Reviewed By: ziqih

Differential Revision: D37526228

