### PR TITLE
Add function to get list of files in Storage Service

### DIFF
--- a/fbpcp/service/storage.py
+++ b/fbpcp/service/storage.py
@@ -71,3 +71,7 @@ class StorageService(abc.ABC):
     @abc.abstractmethod
     def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
         pass
+
+    @abc.abstractmethod
+    def list_files(self, dirPath: str) -> List[str]:
+        pass

--- a/fbpcp/service/storage_gcs.py
+++ b/fbpcp/service/storage_gcs.py
@@ -282,3 +282,6 @@ class GCSStorageService(StorageService):
 
     def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
         raise NotImplementedError
+
+    def list_files(self, dirPath: str) -> List[str]:
+        raise NotImplementedError

--- a/fbpcp/service/storage_s3.py
+++ b/fbpcp/service/storage_s3.py
@@ -220,3 +220,11 @@ class S3StorageService(StorageService):
 
     def get_bucket_public_access_block(self, bucket: str) -> PublicAccessBlockConfig:
         return self.s3_gateway.get_public_access_block(bucket)
+
+    def list_files(self, dirPath: str) -> List[str]:
+        """Returns all paths of files in folders and sub folders recursively
+        Keyword arguments:
+        dirPath -- s3 dir path
+        """
+        s3_path = S3Path(dirPath)
+        return self.s3_gateway.list_object2(s3_path.bucket, s3_path.key)

--- a/tests/service/test_storage_s3.py
+++ b/tests/service/test_storage_s3.py
@@ -211,3 +211,10 @@ class TestS3StorageService(unittest.TestCase):
         service.s3_gateway = MockS3Gateway()
         service.file_exists(self.S3_FILE)
         service.s3_gateway.object_exists.assert_called_with("bucket", "test_file")
+
+    @patch("fbpcp.gateway.s3.S3Gateway")
+    def test_list_files(self, MockS3Gateway):
+        service = S3StorageService("us-west-1")
+        service.s3_gateway = MockS3Gateway()
+        service.list_files(self.S3_FOLDER)
+        service.s3_gateway.list_object2.assert_called_with("bucket", "test_folder")


### PR DESCRIPTION
Summary:
**Context:**
Currently we have a post processing handler in PID where it needs to read the all the metric files in a directory and compute intersection rate.

In order to get the names of all the metric files, we build all the possible paths that end with "_metrics" and check if each of the path is in the file system (s3). This is causing too many calls to s3 api. For example a PC run with 30 shards will make 30 calls to check if each of the metric paths exist. We have also seen a customer issue related to this.(related [post](https://fb.workplace.com/groups/331044242148818/permalink/516307276955846/))

**This diff:**
We add a new function to list files in the storage service that will help reduces the number of calls where we get the list of files in a directory.

Reviewed By: zhuang-93

Differential Revision: D37778726

