### PR TITLE
Update lint dependencies in OSS repo to be consistent with devserver

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -1,5 +1,6 @@
-black==21.4b2
-ufmt==1.2
-usort==0.6.4
+black==22.3.0
+ufmt==2.0.0b2
+usort==1.0.2
+libcst==0.4.6
 flake8==3.9.0
 flake8-bugbear==21.3.2


### PR DESCRIPTION
Summary:
D37229577 ran into an lint error in OSS CI/CD. This might be cause be inconsistency between internal and OSS lint setup.

Following best practice [here](https://www.internalfb.com/intern/wiki/Python/Code_Formatting/Pyfmt/), this diff updated the versions in lint_requirements.txt

Differential Revision: D37903502

