### PR TITLE
Fixing CLI test

### DIFF
--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import shlex
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Final, Iterator, List, Optional, Tuple
 
@@ -93,7 +94,7 @@ class ECSGateway(AWSGateway, MetricsGetter):
                 "containerOverrides": [
                     {
                         "name": container,
-                        "command": [cmd],
+                        "command": shlex.split(cmd),
                         "environment": environment,
                     }
                 ]


### PR DESCRIPTION
Summary:
1. AWS moved from taking a string command to requiring all cmds to be a list based on the spacing.
2. Logs now follow a log group name based on the task definition and log stream name based on container, updated to match that

Differential Revision: D38183976

