### PR TITLE
implement promote API

### DIFF
--- a/onedocker/repository/onedocker_package.py
+++ b/onedocker/repository/onedocker_package.py
@@ -16,15 +16,15 @@ class OneDockerPackageRepository:
         self.storage_svc = storage_svc
         self.repository_path = repository_path
 
-    def _build_package_path(self, package_name: str, version: str) -> str:
+    def build_package_path(self, package_name: str, version: str) -> str:
         return f"{self.repository_path}{package_name}/{version}/{package_name.split('/')[-1]}"
 
     def upload(self, package_name: str, version: str, source: str) -> None:
-        package_path = self._build_package_path(package_name, version)
+        package_path = self.build_package_path(package_name, version)
         self.storage_svc.copy(source, package_path)
 
     def download(self, package_name: str, version: str, destination: str) -> None:
-        package_path = self._build_package_path(package_name, version)
+        package_path = self.build_package_path(package_name, version)
         self.storage_svc.copy(package_path, destination)
 
     def get_package_versions(
@@ -35,7 +35,7 @@ class OneDockerPackageRepository:
         return self.storage_svc.list_folders(package_parent_path)
 
     def get_package_info(self, package_name: str, version: str) -> PackageInfo:
-        package_path = self._build_package_path(package_name, version)
+        package_path = self.build_package_path(package_name, version)
 
         if not self.storage_svc.file_exists(package_path):
             raise ValueError(

--- a/onedocker/repository/onedocker_repository_service.py
+++ b/onedocker/repository/onedocker_repository_service.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
@@ -10,7 +11,7 @@ from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
 
 
-class OnedockerRepositoryService:
+class OneDockerRepositoryService:
     def __init__(
         self,
         storage_svc: StorageService,
@@ -32,7 +33,8 @@ class OnedockerRepositoryService:
         source: str,
         metadata: Optional[dict] = None,
     ) -> None:
-        raise NotImplementedError
+        # TODO: T127441856 handle storing metadata
+        self.package_repo.upload(package_name, version, source)
 
     def download(self, package_name: str, version: str, destination: str) -> None:
         raise NotImplementedError

--- a/onedocker/tests/repository/test_onedocker_repository_service.py
+++ b/onedocker/tests/repository/test_onedocker_repository_service.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from onedocker.repository.onedocker_repository_service import OneDockerRepositoryService
+
+
+class TestOneDockerRepositoryService(unittest.TestCase):
+    TEST_PACKAGE_PATH = "private_lift/lift"
+    TEST_PACKAGE_NAME = TEST_PACKAGE_PATH.split("/")[-1]
+    TEST_PACKAGE_VERSION = "latest"
+
+    @patch(
+        "onedocker.repository.onedocker_repository_service.OneDockerChecksumRepository"
+    )
+    @patch(
+        "onedocker.repository.onedocker_repository_service.OneDockerPackageRepository"
+    )
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def setUp(
+        self, mockStorageService, mockPackageRepoCall, mockChecksumRepoCall
+    ) -> None:
+        package_repo_path = "/package_repo_path/"
+        checksum_repo_path = "/checksum_repo_path/"
+        self.package_repo = MagicMock()
+        mockPackageRepoCall.return_value = self.package_repo
+        self.repo_service = OneDockerRepositoryService(
+            mockStorageService, package_repo_path, checksum_repo_path
+        )
+
+    def test_onedocker_repo_service_upload(self) -> None:
+        # Arrange
+        source_path = "test_source_path"
+
+        # Act
+        self.repo_service.upload(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, source_path
+        )
+
+        # Assert
+        self.package_repo.upload.assert_called_with(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, source_path
+        )

--- a/onedocker/tests/repository/test_onedocker_repository_service.py
+++ b/onedocker/tests/repository/test_onedocker_repository_service.py
@@ -5,7 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import MagicMock, patch
+from datetime import datetime
+from unittest.mock import call, MagicMock, patch
+
+from onedocker.entity.package_info import PackageInfo
 
 from onedocker.repository.onedocker_repository_service import OneDockerRepositoryService
 
@@ -13,7 +16,7 @@ from onedocker.repository.onedocker_repository_service import OneDockerRepositor
 class TestOneDockerRepositoryService(unittest.TestCase):
     TEST_PACKAGE_PATH = "private_lift/lift"
     TEST_PACKAGE_NAME = TEST_PACKAGE_PATH.split("/")[-1]
-    TEST_PACKAGE_VERSION = "latest"
+    TEST_PACKAGE_VERSION = "test_version"
 
     @patch(
         "onedocker.repository.onedocker_repository_service.OneDockerChecksumRepository"
@@ -25,12 +28,16 @@ class TestOneDockerRepositoryService(unittest.TestCase):
     def setUp(
         self, mockStorageService, mockPackageRepoCall, mockChecksumRepoCall
     ) -> None:
-        package_repo_path = "/package_repo_path/"
+        self.package_repo_path = "/package_repo_path/"
         checksum_repo_path = "/checksum_repo_path/"
         self.package_repo = MagicMock()
         mockPackageRepoCall.return_value = self.package_repo
         self.repo_service = OneDockerRepositoryService(
-            mockStorageService, package_repo_path, checksum_repo_path
+            mockStorageService, self.package_repo_path, checksum_repo_path
+        )
+        self.storage_svc = mockStorageService
+        self.package_repo.build_package_path = MagicMock(
+            side_effect=self._build_package_path
         )
 
     def test_onedocker_repo_service_upload(self) -> None:
@@ -46,3 +53,44 @@ class TestOneDockerRepositoryService(unittest.TestCase):
         self.package_repo.upload.assert_called_with(
             self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, source_path
         )
+
+    def _build_package_path(self, package_name: str, version: str) -> str:
+        return f"{self.package_repo_path}{self.TEST_PACKAGE_NAME}/{version}/{package_name.split('/')[-1]}"
+
+    def test_onedocker_repo_service_promote_to_latest(self) -> None:
+        # Arrange
+        old_version = self.TEST_PACKAGE_VERSION
+        new_version = "latest"
+        date = datetime.today().ctime()
+        formatted_date = datetime.strftime(
+            datetime.strptime(date, "%a %b %d %H:%M:%S %Y"),
+            "%Y-%m-%d",
+        )
+        self.package_repo.get_package_info.return_value = PackageInfo(
+            package_name=self.TEST_PACKAGE_NAME,
+            version=old_version,
+            last_modified=date,
+            package_size=1,
+        )
+        target_path = self._build_package_path(self.TEST_PACKAGE_NAME, new_version)
+        current_path = self._build_package_path(self.TEST_PACKAGE_NAME, old_version)
+        archive_path = self._build_package_path(self.TEST_PACKAGE_NAME, formatted_date)
+        # Act
+        self.repo_service.promote(self.TEST_PACKAGE_PATH, old_version, new_version)
+
+        # Assert
+        self.storage_svc.copy.assert_has_calls(
+            [call(target_path, archive_path), call(current_path, target_path)]
+        )
+
+    def test_onedocker_repo_service_promote(self) -> None:
+        # Arrange
+        old_version = self.TEST_PACKAGE_VERSION
+        new_version = "rc"
+        target_path = self._build_package_path(self.TEST_PACKAGE_NAME, new_version)
+        current_path = self._build_package_path(self.TEST_PACKAGE_NAME, old_version)
+        # Act
+        self.repo_service.promote(self.TEST_PACKAGE_PATH, old_version, new_version)
+
+        # Assert
+        self.storage_svc.copy.assert_called_once_with(current_path, target_path)


### PR DESCRIPTION
Summary: According to the [promote script](https://www.internalfb.com/code/fbsource/fbcode/fbpcs/public_tld/promote_scripts/promote_binaries.sh), when a file is promoted to latest, we first archive the existing file under latest folder, then promote the current file to the latest folder. For other promotions, we simply overwrite the files with the promoted ones.

Differential Revision: D38245271

