### PR TITLE
add an archive version API

### DIFF
--- a/onedocker/repository/onedocker_checksum.py
+++ b/onedocker/repository/onedocker_checksum.py
@@ -46,3 +46,6 @@ class OneDockerChecksumRepository:
             )
 
         return self.storage_svc.read(filename=package_path)
+
+    def archive_file(self, package_name: str, version: str) -> None:
+        raise NotImplementedError

--- a/onedocker/repository/onedocker_package.py
+++ b/onedocker/repository/onedocker_package.py
@@ -49,3 +49,6 @@ class OneDockerPackageRepository:
             last_modified=file_info.last_modified,
             package_size=file_info.file_size,
         )
+
+    def archive_file(self, package_name: str, version: str) -> None:
+        raise NotImplementedError

--- a/onedocker/repository/onedocker_repository_service.py
+++ b/onedocker/repository/onedocker_repository_service.py
@@ -39,9 +39,6 @@ class OneDockerRepositoryService:
     def download(self, package_name: str, version: str, destination: str) -> None:
         self.package_repo.download(package_name, version, destination)
 
-    def promote(self, package_name: str, old_version: str, new_version: str) -> None:
-        raise NotImplementedError
-
     def _set_metadata(
         self,
         package_name: str,
@@ -57,3 +54,7 @@ class OneDockerRepositoryService:
         version: str,
     ) -> PackageMetadata:
         raise NotImplementedError
+
+    def archive_file(self, package_name: str, version: str) -> None:
+        self.package_repo.archive_file(package_name, version)
+        self.checksum_repo.archive_file(package_name, version)

--- a/onedocker/tests/repository/test_onedocker_repository_service.py
+++ b/onedocker/tests/repository/test_onedocker_repository_service.py
@@ -28,7 +28,9 @@ class TestOneDockerRepositoryService(unittest.TestCase):
         package_repo_path = "/package_repo_path/"
         checksum_repo_path = "/checksum_repo_path/"
         self.package_repo = MagicMock()
+        self.checksum_repo = MagicMock()
         mockPackageRepoCall.return_value = self.package_repo
+        mockChecksumRepoCall.return_value = self.checksum_repo
         self.repo_service = OneDockerRepositoryService(
             mockStorageService, package_repo_path, checksum_repo_path
         )
@@ -59,4 +61,17 @@ class TestOneDockerRepositoryService(unittest.TestCase):
         # Assert
         self.package_repo.download.assert_called_with(
             self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, destination
+        )
+
+    def test_onedocker_repo_service_archive(self) -> None:
+        # Act
+        self.repo_service.archive_file(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
+        )
+        # Assert
+        self.package_repo.archive_file.assert_called_once_with(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
+        )
+        self.checksum_repo.archive_file.assert_called_once_with(
+            self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
         )


### PR DESCRIPTION
Summary:
This API will be used to archive old versions, by moving the specified version to the archived folder.

Next step is to set up a chronos job to clean up the archive folder.

Differential Revision: D38327373

