### PR TITLE
Add getter and setter APIs for metadata

### DIFF
--- a/onedocker/entity/object_metadata.py
+++ b/onedocker/entity/object_metadata.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PackageMetadata:
+    checksum: Optional[str] = None

--- a/onedocker/repository/onedocker_repository_service.py
+++ b/onedocker/repository/onedocker_repository_service.py
@@ -7,6 +7,7 @@
 from typing import Optional
 
 from fbpcp.service.storage import StorageService
+from onedocker.entity.object_metadata import PackageMetadata
 from onedocker.repository.onedocker_checksum import OneDockerChecksumRepository
 from onedocker.repository.onedocker_package import OneDockerPackageRepository
 
@@ -33,11 +34,26 @@ class OneDockerRepositoryService:
         source: str,
         metadata: Optional[dict] = None,
     ) -> None:
-        # TODO: T127441856 handle storing metadata
         self.package_repo.upload(package_name, version, source)
 
     def download(self, package_name: str, version: str, destination: str) -> None:
         self.package_repo.download(package_name, version, destination)
 
     def promote(self, package_name: str, old_version: str, new_version: str) -> None:
+        raise NotImplementedError
+
+    def _set_metadata(
+        self,
+        package_name: str,
+        version: str,
+        metadata: PackageMetadata,
+    ) -> None:
+        # TODO: T127441856 handle storing metadata
+        raise NotImplementedError
+
+    def _get_metadata(
+        self,
+        package_name: str,
+        version: str,
+    ) -> PackageMetadata:
         raise NotImplementedError


### PR DESCRIPTION
Summary:
with this API in onedocker_cli.py, we can replace [this code](https://fburl.com/code/z3avsncu) with

```
repo_service.set_metadata(package_name, version, ObjectMetadata(checksum=formatted_checksum_info))
```

Reviewed By: ziqih

Differential Revision: D38329869

