### PR TITLE
Remove Command Split

### DIFF
--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-
-import shlex
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, Final, Iterator, List, Optional, Tuple
 
@@ -94,7 +92,7 @@ class ECSGateway(AWSGateway, MetricsGetter):
                 "containerOverrides": [
                     {
                         "name": container,
-                        "command": shlex.split(cmd),
+                        "command": [cmd],  # Quick fix for T127974788
                         "environment": environment,
                     }
                 ]

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import shlex
 import unittest
 from typing import Callable, Dict, List
 from unittest.mock import call, MagicMock, patch
@@ -99,60 +98,6 @@ class TestECSGateway(unittest.TestCase):
                     {
                         "name": self.TEST_CONTAINER,
                         "command": [self.TEST_CMD],
-                        "environment": [],
-                    }
-                ]
-            },
-        )
-
-    def test_run_task_with_args(self) -> None:
-        client_return_response = {
-            "tasks": [
-                {
-                    "containers": [
-                        {
-                            "name": "container_1",
-                            "exitcode": 123,
-                            "lastStatus": "RUNNING",
-                            "networkInterfaces": [
-                                {
-                                    "privateIpv4Address": self.TEST_IP_ADDRESS,
-                                },
-                            ],
-                        }
-                    ],
-                    "taskArn": self.TEST_TASK_ARN,
-                }
-            ]
-        }
-        self.gw.client.run_task = MagicMock(return_value=client_return_response)
-        task = self.gw.run_task(
-            self.TEST_TASK_DEFINITION,
-            self.TEST_CONTAINER,
-            shlex.join(self.TEST_CMD_WITH_ARGS),
-            self.TEST_CLUSTER,
-            self.TEST_SUBNETS,
-        )
-        expected_task = ContainerInstance(
-            self.TEST_TASK_ARN,
-            self.TEST_IP_ADDRESS,
-            ContainerInstanceStatus.STARTED,
-        )
-        self.assertEqual(task, expected_task)
-        self.gw.client.run_task.assert_called_once_with(
-            taskDefinition=self.TEST_TASK_DEFINITION,
-            cluster=self.TEST_CLUSTER,
-            networkConfiguration={
-                "awsvpcConfiguration": {
-                    "subnets": self.TEST_SUBNETS,
-                    "assignPublicIp": "ENABLED",
-                }
-            },
-            overrides={
-                "containerOverrides": [
-                    {
-                        "name": self.TEST_CONTAINER,
-                        "command": self.TEST_CMD_WITH_ARGS,
                         "environment": [],
                     }
                 ]


### PR DESCRIPTION
Summary:
Addressed the problem caused by the command splitting in D38183976 (https://github.com/facebookresearch/fbpcp/commit/a0dbdc99a15365bdd4a326a238be965bc240251e). It results our PCE deployment script fail to run.

The problematic command to run in the container
```
 ["python3.8","-m","onedocker.script.runner","deploy.sh","--exe_args= deploy --tag 'd0725f0641544999bd5ecbae7752e73b' --region 'us-west-1' --account_id '042466421689' --publisher_vpc_cidr '10.0.0.0/16' --partner_vpc_cidr '10.1.0.0/16' --bucket 'pce-deployment-042466421689' --bucket_region 'us-west-2'","--version=latest"]
```

Expected command
```
["python3.8 -m onedocker.script.runner deploy.sh --exe_args=' deploy --tag '\"'\"'684eeb991e6045df93c68a6bd5e1bfd6'\"'\"' --region '\"'\"'us-west-2'\"'\"' --account_id '\"'\"'042466421689'\"'\"' --publisher_vpc_cidr '\"'\"'10.0.0.0/16'\"'\"' --partner_vpc_cidr '\"'\"'10.1.0.0/16'\"'\"' --bucket '\"'\"'pce-deployment-042466421689'\"'\"' --bucket_region '\"'\"'us-west-2'\"'\"'' --version=latest"]
```

As a quick fix to unblock xfn team. The splitting logic and related test was removed for now.

Reviewed By: wenqingren

Differential Revision: D38371909

