### PR TITLE
Fix the bug that OneDocker unable to pass override env vars to ecs gateway

### DIFF
--- a/fbpcp/gateway/ecs.py
+++ b/fbpcp/gateway/ecs.py
@@ -73,9 +73,9 @@ class ECSGateway(AWSGateway, MetricsGetter):
         cmd: str,
         cluster: str,
         subnets: List[str],
+        env_vars: Optional[Dict[str, str]] = None,
         cpu: Optional[int] = None,
         memory: Optional[int] = None,
-        env_vars: Optional[Dict[str, str]] = None,
     ) -> ContainerInstance:
         environment = []
         if env_vars:

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -64,7 +64,12 @@ class AWSContainerService(ContainerService):
             )
 
         return self.ecs_gateway.run_task(
-            task_definition, container, cmd, self.cluster, self.subnets, env_vars
+            task_definition=task_definition,
+            container=container,
+            cmd=cmd,
+            cluster=self.cluster,
+            subnets=self.subnets,
+            env_vars=env_vars,
         )
 
     def create_instances(


### PR DESCRIPTION
Summary:
TLDR OneDocker is unable to pass env vars to ecs gateway.

For more context: T128688735

Differential Revision: D38607256

