### PR TITLE
Remove unrelated API out of container service

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -109,11 +109,3 @@ class ContainerService(abc.ABC):
             Integer that represent the total pending and running instances count for cluster
         """
         pass
-
-    @abc.abstractmethod
-    def validate_container_definition(self, container_definition: str) -> None:
-        """Validate the format of a specific container definition.
-        Raises:
-            InvalidParameterError: The container definition is not in a valid format.
-        """
-        pass

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -50,8 +50,6 @@ class OneDockerService(MetricsGetter):
         if container_svc is None:
             raise ValueError(f"Dependency is missing. container_svc={container_svc}, ")
         self.container_svc = container_svc
-        if task_definition:
-            self.container_svc.validate_container_definition(task_definition)
         self.task_definition = task_definition
         self.metrics: Final[Optional[MetricsEmitter]] = metrics
         self.logger: logging.Logger = logging.getLogger(__name__)
@@ -140,8 +138,6 @@ class OneDockerService(MetricsGetter):
         Returns:
             A list of the containers that were successfuly started
         """
-        if task_definition:
-            self.container_svc.validate_container_definition(task_definition)
         if not cmd_args_list:
             raise ValueError("Command Argument List shouldn't be None or Empty")
 


### PR DESCRIPTION
Summary:
We decided that validate_container_definitions should not be a public API in container service. This diff is to remove it and resolve the conflict.

Next diff is to move it to util

Differential Revision: D38604420

