### PR TITLE
Have container definition validate logic in util

### DIFF
--- a/fbpcp/util/aws.py
+++ b/fbpcp/util/aws.py
@@ -7,8 +7,11 @@
 # pyre-strict
 
 
+import re
 from functools import reduce
 from typing import Any, Dict, List, Optional, Tuple, Union
+
+from fbpcp.error.pcp import InvalidParameterError
 
 
 def convert_dict_to_list(
@@ -108,5 +111,14 @@ def split_container_definition(container_definition: str) -> Tuple[str, str]:
     container: ECS cluster name, e.g. test-cluster
     example: test-definition:1#test-cluster
     """
+    if not is_container_definition_valid(container_definition):
+        raise InvalidParameterError(
+            "Parameter container_definition must be in format <task definition name>:<revision>#<container name>"
+        )
     s = container_definition.split("#")
     return (s[0], s[1])
+
+
+def is_container_definition_valid(container_definition: str) -> bool:
+    is_valid = bool(re.fullmatch(r"[\w\-/:]+?:\d+#[\w\-/]+?", container_definition))
+    return is_valid

--- a/tests/util/test_aws.py
+++ b/tests/util/test_aws.py
@@ -6,7 +6,15 @@
 
 import unittest
 
-from fbpcp.util.aws import convert_dict_to_list, convert_list_to_dict, prepare_tags
+from fbpcp.error.pcp import InvalidParameterError
+
+from fbpcp.util.aws import (
+    convert_dict_to_list,
+    convert_list_to_dict,
+    is_container_definition_valid,
+    prepare_tags,
+    split_container_definition,
+)
 
 TEST_DICT = {"k1": "v1", "k2": "v2"}
 TEST_LIST = [{"Name": "k1", "Value": "v1"}, {"Name": "k2", "Value": "v2"}]
@@ -29,3 +37,47 @@ class TestAWSUtil(unittest.TestCase):
     def test_prepare_tags(self):
         expected_tags = {"tag:k1": "v1", "tag:k2": "v2"}
         self.assertEqual(expected_tags, prepare_tags(TEST_DICT))
+
+    def test_is_container_definition_valid_true(self):
+        # Arrange
+        valid_container_definitions = [
+            "pl-task-fake-business:2#pl-container-fake-business",
+            "arn:aws:ecs:us-west-2:123456789012:task-definition/onedocker-task-shared-us-west-2:1#onedocker-container-shared-us-west-2",
+        ]
+
+        # Act and Assert
+        for container_definition in valid_container_definitions:
+            self.assertTrue(is_container_definition_valid(container_definition))
+
+    def test_is_container_definition_valid_false(self):
+        # Arrange
+        invalid_container_definitions = [
+            "pl-task-fake-business:2#",
+            "pl-task-fake-business:2##pl-container-fake-business",
+            "pl-task-fake-business#pl-container-fake-business",
+            "pl-container-fake-business",
+        ]
+
+        # Act and Assert
+        for container_definition in invalid_container_definitions:
+            self.assertFalse(is_container_definition_valid(container_definition))
+
+    def test_split_container_definition_throw(self):
+        # Arrange
+        invalid_container_definition = "pl-task-fake-business:2#"
+
+        # Act & Assert
+        with self.assertRaises(InvalidParameterError):
+            split_container_definition(invalid_container_definition)
+
+    def test_split_container_definition(self):
+        # Arrange
+        valid_container_definition = (
+            "pl-task-fake-business:2#pl-container-fake-business"
+        )
+
+        # Act & Assert
+        self.assertEqual(
+            ("pl-task-fake-business:2", "pl-container-fake-business"),
+            split_container_definition(valid_container_definition),
+        )


### PR DESCRIPTION
Summary:
## Context

Currently container validation is in container service as an interface, however we agreed that it should not be a public API in container service. To ensure the backward compatibility, we firstly introduced the same logic in util.

## Summary
1. Have the same container definition validation logic in util functions
2. Re-scope its functionality to is_x_valid
3. Add more tests

## Next
1. Remove dependencies of validate_container_definition in container service.

Differential Revision: D38629555

