### PR TITLE
Attempt to fix flaky test in test_onedocker_runner

### DIFF
--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -235,10 +235,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 "--repository_path=local",
             ],
         ):
-            with patch(
-                "os.getenv",
-                side_effect=lambda x: getenv(x),
-            ):
+            with patch("os.getenv", return_value=None):
                 with self.assertRaises(SystemExit) as cm:
                     main()
                 # Assert


### PR DESCRIPTION
Summary:
Oncall received flaky test notification, but  it is unable to repro either on devserver or ondemand.

This diff is an attempt to fix the issue and will re-visit if we still see the flaky test.

Differential Revision: D38680980

