### PR TITLE
Add get cluster instance method to container service

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -9,6 +9,8 @@
 import abc
 from typing import Dict, List, Optional
 
+from fbpcp.entity.cluster_instance import Cluster
+
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 
@@ -107,5 +109,13 @@ class ContainerService(abc.ABC):
         """Get total pending and running instances count for cluster
         Returns:
             Integer that represent the total pending and running instances count for cluster
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_cluster_instance(self) -> Cluster:
+        """Get cluster instance
+        Returns:
+            Cluster that represent a cluster instance
         """
         pass

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -9,6 +9,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+from fbpcp.entity.cluster_instance import Cluster
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.gateway.ecs import ECSGateway
@@ -126,3 +127,7 @@ class AWSContainerService(ContainerService):
     def get_current_instances_count(self) -> int:
         cluster = self.ecs_gateway.describe_cluster(self.cluster)
         return cluster.running_tasks + cluster.pending_tasks
+
+    def get_cluster_instance(self) -> Cluster:
+        cluster = self.ecs_gateway.describe_cluster(self.cluster)
+        return cluster


### PR DESCRIPTION
Summary:
Sync with Ajay, Michael, Ziyan, Ji and Gary offline about this implementation.
Add get_cluster_instance method to container service, which is used to retrieve the cluster status information from cloud provider, and implement this method on container_aws.py and other child class of ContainerService
diff D38749175 is to add get_cluster_instance implementation to PCSContainerService in pce_container_serice.py and it was landed

Reviewed By: zhuang-93

Differential Revision: D38402961

