### PR TITLE
short term solution to resolve backward compatibility

### DIFF
--- a/onedocker/tests/repository/test_onedocker_repository_service.py
+++ b/onedocker/tests/repository/test_onedocker_repository_service.py
@@ -7,13 +7,16 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from onedocker.repository.onedocker_repository_service import OneDockerRepositoryService
+from onedocker.repository.onedocker_repository_service import (
+    DEFAULT_PROD_VERSION,
+    OneDockerRepositoryService,
+)
 
 
 class TestOneDockerRepositoryService(unittest.TestCase):
     TEST_PACKAGE_PATH = "private_lift/lift"
     TEST_PACKAGE_NAME = TEST_PACKAGE_PATH.split("/")[-1]
-    TEST_PACKAGE_VERSION = "latest"
+    TEST_PACKAGE_VERSION = "1.0"
 
     @patch(
         "onedocker.repository.onedocker_repository_service.OneDockerPackageRepository"
@@ -37,6 +40,9 @@ class TestOneDockerRepositoryService(unittest.TestCase):
         )
 
         # Assert
+        self.package_repo.get_package_versions.assert_called_with(
+            self.TEST_PACKAGE_PATH
+        )
         self.package_repo.upload.assert_called_with(
             self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION, source_path
         )
@@ -63,4 +69,19 @@ class TestOneDockerRepositoryService(unittest.TestCase):
         # Assert
         self.package_repo.archive_package.assert_called_once_with(
             self.TEST_PACKAGE_PATH, self.TEST_PACKAGE_VERSION
+        )
+
+    def test_onedocker_repo_service_upload_to_latest(self) -> None:
+        # Arrange
+        source_path = "test_source_path"
+
+        # Act
+        self.repo_service.upload(
+            self.TEST_PACKAGE_PATH, DEFAULT_PROD_VERSION, source_path
+        )
+
+        # Assert
+        self.package_repo.get_package_versions.assert_not_called()
+        self.package_repo.upload.assert_called_with(
+            self.TEST_PACKAGE_PATH, DEFAULT_PROD_VERSION, source_path
         )

--- a/onedocker/tests/script/cli/test_onedocker_cli.py
+++ b/onedocker/tests/script/cli/test_onedocker_cli.py
@@ -270,7 +270,11 @@ class TestOnedockerCli(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected_args, args)
 
-    def test_upload(self):
+    @patch(
+        "onedocker.repository.onedocker_repository_service.OneDockerRepositoryService._skip_version_validation_check",
+        return_value=True,
+    )
+    def test_upload(self, mockRepoSvc):
         # Arrange & Act
         with patch.object(
             sys,


### PR DESCRIPTION
Summary:
**What's the problem?**
Onedocker runner and other services currently rely on a [hardcoded default version](https://fburl.com/code/tu8be5nx) to retrieve the binaries. With the new build and release process, binaries will no longer be versioned by stage names (i.e. "rc", "canary", "latest"), but will be given version numbers instead. Therefore, this might introduce breaks for advertiser runs that rely on the default value. This is currently a blocker for account migration in onedocker_runner.

**What does this diff do?**
This diff provides a way for the upload API to skip version validation check when the version is "latest". With this change, B&R will be able to upload to "latest" to ensure backward compatibility. We expect B&R to first call upload with a version number, then call upload with "latest" version at a proper stage.

**Why is this only a short term change and what's the long term solution?**
As I discussed with musebc, the long term solution would be for the build and release to provide a config with the prod version number that can be read during each run. The config will be updated during the build and release process to reflect the latest prod version number.

Differential Revision: D38745356

