### PR TITLE
add unit test on get_cluster_instance method

### DIFF
--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -9,7 +9,7 @@ import unittest
 from unittest.mock import call, MagicMock, patch
 from uuid import uuid4
 
-from fbpcp.entity.cluster_instance import Cluster
+from fbpcp.entity.cluster_instance import Cluster, ClusterStatus
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.container_aws import AWS_API_INPUT_SIZE_LIMIT, AWSContainerService
@@ -271,3 +271,31 @@ class TestAWSContainerService(unittest.TestCase):
         }
 
         self.assertEqual(container_aws.ecs_gateway.config, expected_config)
+
+    def test_get_cluster_instance(self) -> None:
+        # Arrange
+        test_cluster_arn = "test_cluster_arn"
+        test_cluster_name = TEST_CLUSTER
+        test_pending_tasks_account = 2
+        test_running_tasks_account = 3
+        test_status = ClusterStatus.ACTIVE
+        self.container_svc.ecs_gateway.describe_cluster = MagicMock(
+            return_value=Cluster(
+                cluster_arn=test_cluster_arn,
+                cluster_name=test_cluster_name,
+                pending_tasks=test_pending_tasks_account,
+                running_tasks=test_running_tasks_account,
+                status=test_status,
+            )
+        )
+        expected_cluster_instance = Cluster(
+            cluster_arn=test_cluster_arn,
+            cluster_name=test_cluster_name,
+            pending_tasks=test_pending_tasks_account,
+            running_tasks=test_running_tasks_account,
+            status=test_status,
+        )
+        # Act
+        cluster_instance = self.container_svc.get_cluster_instance()
+        # Assert
+        self.assertEqual(cluster_instance, expected_cluster_instance)


### PR DESCRIPTION
Summary:
get_cluster_instance is implemented in container_aws.py,
# what this diff does:
add unit test to get_cluster_instance method

Differential Revision: D38450142

