### PR TITLE
Make CloudProvider entity OSS

### DIFF
--- a/fbpcp/entity/cloud_provider.py
+++ b/fbpcp/entity/cloud_provider.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from enum import Enum
+
+
+class CloudProvider(Enum):
+    AWS = "AWS"
+    GCP = "GCP"
+    AZURE = "AZURE"

--- a/fbpcp/entity/container_instance.py
+++ b/fbpcp/entity/container_instance.py
@@ -26,3 +26,5 @@ class ContainerInstance:
     instance_id: str
     ip_address: Optional[str] = None
     status: ContainerInstanceStatus = ContainerInstanceStatus.UNKNOWN
+    cpu: Optional[int] = None  # Number of vCPU
+    memory: Optional[int] = None  # Memory in GB

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -44,12 +44,12 @@ def map_gb_to_mb(gb: int) -> int:
     return gb * MEMORY_GB_TO_MB
 
 
-def map_unit_to_vcpu(cpu_unit: int) -> int:
-    return cpu_unit // CPU_VIRTUAL_TO_UNIT
+def map_unit_to_vcpu(cpu_unit: str) -> int:
+    return int(cpu_unit) // CPU_VIRTUAL_TO_UNIT
 
 
-def map_mb_to_gb(mb: int) -> int:
-    return mb // MEMORY_GB_TO_MB
+def map_mb_to_gb(mb: str) -> int:
+    return int(mb) // MEMORY_GB_TO_MB
 
 
 def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
@@ -70,8 +70,15 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
             status = ContainerInstanceStatus.FAILED
     else:
         status = ContainerInstanceStatus.UNKNOWN
-
-    return ContainerInstance(task["taskArn"], ip_v4, status)
+    vcpu = map_unit_to_vcpu(task["cpu"]) if "cpu" in task else None
+    memory_in_gb = map_mb_to_gb(task["memory"]) if "memory" in task else None
+    return ContainerInstance(
+        instance_id=task["taskArn"],
+        ip_address=ip_v4,
+        status=status,
+        cpu=vcpu,
+        memory=memory_in_gb,
+    )
 
 
 def map_esccluster_to_clusterinstance(cluster: Dict[str, Any]) -> Cluster:

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -88,6 +88,8 @@ class TestECSGateway(unittest.TestCase):
                         "cpu": str(cpu_response),
                         "memory": str(memory_response),
                     },
+                    "cpu": str(cpu_response),
+                    "memory": str(memory_response),
                 },
             ]
         }
@@ -96,6 +98,8 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_TASK_ARN,
             self.TEST_IP_ADDRESS,
             ContainerInstanceStatus.STARTED,
+            self.TEST_CPU,
+            self.TEST_MEMORY,
         )
         # Act
         task = self.gw.run_task(

--- a/tests/mapper/test_aws.py
+++ b/tests/mapper/test_aws.py
@@ -40,6 +40,7 @@ class TestAWSMapper(unittest.TestCase):
     TEST_MEMORY = 2
 
     def test_map_ecstask_to_containerinstance(self):
+        # Arrange
         cpu_response = map_vcpu_to_unit(self.TEST_CPU)
         memory_response = map_gb_to_mb(self.TEST_MEMORY)
         ecs_task_response = {
@@ -79,10 +80,6 @@ class TestAWSMapper(unittest.TestCase):
                         },
                     ],
                     "taskArn": self.TEST_TASK_ARN,
-                    "overrides": {
-                        "cpu": cpu_response,
-                        "memory": memory_response,
-                    },
                 },
                 {
                     "containers": [
@@ -96,7 +93,6 @@ class TestAWSMapper(unittest.TestCase):
                 },
             ]
         }
-
         expected_task_list = [
             ContainerInstance(
                 self.TEST_TASK_ARN,
@@ -107,23 +103,22 @@ class TestAWSMapper(unittest.TestCase):
                 self.TEST_TASK_ARN,
                 None,
                 ContainerInstanceStatus.COMPLETED,
+                cpu=self.TEST_CPU,
+                memory=self.TEST_MEMORY,
             ),
-            ContainerInstance(
-                self.TEST_TASK_ARN,
-                None,
-                ContainerInstanceStatus.FAILED,
-            ),
+            ContainerInstance(self.TEST_TASK_ARN, None, ContainerInstanceStatus.FAILED),
             ContainerInstance(
                 self.TEST_TASK_ARN,
                 None,
                 ContainerInstanceStatus.UNKNOWN,
             ),
         ]
+        # Act
         tasks_list = [
             map_ecstask_to_containerinstance(task)
             for task in ecs_task_response["tasks"]
         ]
-
+        # Assert
         self.assertEqual(tasks_list, expected_task_list)
 
     def test_map_esccluster_to_clusterinstance(self):


### PR DESCRIPTION
Summary: We need to use the CloudProvider entity in the customized container project; but it's currently intern, move it to OSS in this diff.

Differential Revision: D38848828

