### PR TITLE
use a more proper name for input arg

### DIFF
--- a/onedocker/script/cli/onedocker_cli.py
+++ b/onedocker/script/cli/onedocker_cli.py
@@ -10,7 +10,7 @@ CLI for uploading an executable to one docker repo
 
 
 Usage:
-    onedocker-cli upload --config=<config> --package_name=<package_name> --package_dir=<package_dir> [--version=<version> ] [options]
+    onedocker-cli upload --config=<config> --package_name=<package_name> --package_path=<package_path> [--version=<version> ] [options]
     onedocker-cli archive --config=<config> --package_name=<package_name> [--version=<version> ] [options]
     onedocker-cli test --config=<config> --package_name=<package_name> --cmd_args=<cmd_args> [--version=<version> --timeout=<timeout>][options]
     onedocker-cli show --config=<config> --package_name=<package_name> [--version=<version>] [options]
@@ -52,15 +52,15 @@ DEFAULT_TIMEOUT = 18000
 
 
 def _upload(
-    package_dir: str,
+    package_path: str,
     package_name: str,
     version: str,
 ) -> None:
     logger.info(
-        f" Starting uploading package {package_name} at '{package_dir}', version {version}..."
+        f" Starting uploading package {package_name} at '{package_path}', version {version}..."
     )
     logger.info(f"Uploading binary for package {package_name}: {version}")
-    onedocker_repo_svc.upload(package_name, version, package_dir)
+    onedocker_repo_svc.upload(package_name, version, package_path)
     logger.info(f" Finished uploading '{package_name}, version {version}'.\n")
 
 
@@ -185,7 +185,7 @@ def main() -> None:
             "--help": bool,
             "--config": schema.And(schema.Use(PurePath), os.path.exists),
             "--package_name": schema.Or(None, schema.And(str, len)),
-            "--package_dir": schema.Or(None, schema.And(str, len)),
+            "--package_path": schema.Or(None, schema.And(str, len)),
             "--cmd_args": schema.Or(None, schema.And(str, len)),
             "--container": schema.Or(None, schema.And(str, len)),
             "--log_path": schema.Or(None, schema.Use(Path)),
@@ -201,7 +201,7 @@ def main() -> None:
     logging.basicConfig(filename=log_path, level=log_level)
 
     package_name = arguments["--package_name"]
-    package_dir = arguments["--package_dir"]
+    package_path = arguments["--package_path"]
     version = (
         arguments["--version"] if arguments["--version"] else DEFAULT_BINARY_VERSION
     )
@@ -217,7 +217,7 @@ def main() -> None:
     log_svc = _build_log_service(config["dependency"]["LogService"])
 
     if arguments["upload"]:
-        _upload(package_dir, package_name, version)
+        _upload(package_path, package_name, version)
     elif arguments["archive"]:
         _archive(package_name, version)
     elif arguments["test"]:

--- a/onedocker/tests/script/cli/test_onedocker_cli.py
+++ b/onedocker/tests/script/cli/test_onedocker_cli.py
@@ -49,7 +49,7 @@ class TestOnedockerCli(unittest.TestCase):
         )
 
         self.package_name = "foo"
-        self.package_dir = "test/bar/"
+        self.package_path = "test/bar/"
         self.version = "baz"
         self.config_file = "test_config_file.yml"
         self.timeout = "100"
@@ -73,7 +73,7 @@ class TestOnedockerCli(unittest.TestCase):
             "--verbose": False,
             "--package_name": None,
             "--version": None,
-            "--package_dir": None,
+            "--package_path": None,
             "--config": None,
             "--log_path": None,
             "--cmd_args": None,
@@ -140,7 +140,7 @@ class TestOnedockerCli(unittest.TestCase):
                 "upload": True,
                 "--package_name": self.package_name,
                 "--version": self.version,
-                "--package_dir": self.package_dir,
+                "--package_path": self.package_path,
                 "--config": self.config_file,
             }
         )
@@ -152,7 +152,7 @@ class TestOnedockerCli(unittest.TestCase):
                 "upload",
                 "--config=" + self.config_file,
                 "--package_name=" + self.package_name,
-                "--package_dir=" + self.package_dir,
+                "--package_path=" + self.package_path,
                 "--version=" + self.version,
             ],
         )
@@ -284,7 +284,7 @@ class TestOnedockerCli(unittest.TestCase):
                 "upload",
                 "--config=" + self.config_file,
                 "--package_name=" + self.package_name,
-                "--package_dir=" + self.package_dir,
+                "--package_path=" + self.package_path,
                 "--version=" + self.version,
             ],
         ):
@@ -293,7 +293,7 @@ class TestOnedockerCli(unittest.TestCase):
         # Assert
         self.mockYamlLoad.assert_called_once()
         self.mockODPRUpload.assert_called_once_with(
-            self.package_name, self.version, self.package_dir
+            self.package_name, self.version, self.package_path
         )
 
     def test_archive(self):


### PR DESCRIPTION
Summary:
the input argument `package_dir` is a bit confusing because it suggests that this is the directory where the package lives. However, what this argument really takes is the entire path of the package.

For example, this command failed
```
python3.8 -m onedocker.script.cli upload --config=./config.yml --package_name=private_lift/pcf2_lift --package_dir=./

......
  File "/Users/yigezhu/Library/Python/3.8/lib/python/site-packages/onedocker/repository/onedocker_package.py", line 24, in upload
    self.storage_svc.copy(source, package_path)
  File "/Users/yigezhu/Library/Python/3.8/lib/python/site-packages/fbpcp/service/storage_s3.py", line 64, in copy
    raise ValueError(f"Source {source} is a folder. Use --recursive")
ValueError: Source . is a folder. Use --recursive
```
while this worked:
```
python3.8 -m onedocker.script.cli upload --config=./config.yml --package_name=private_lift/pcf2_lift --package_dir=./pcf2_lift
```
## Next Step
We should probably add in the doc string for what each argument means to make it more user-friendly. I can do this in another diff.

Differential Revision: D38913925

