### PR TITLE
enforce version argument to be present for upload

### DIFF
--- a/onedocker/script/cli/onedocker_cli.py
+++ b/onedocker/script/cli/onedocker_cli.py
@@ -10,7 +10,7 @@ CLI for uploading an executable to one docker repo
 
 
 Usage:
-    onedocker-cli upload --config=<config> --package_name=<package_name> --package_path=<package_path> [--version=<version> ] [options]
+    onedocker-cli upload --config=<config> --package_name=<package_name> --package_path=<package_path> --version=<version>
     onedocker-cli archive --config=<config> --package_name=<package_name> [--version=<version> ] [options]
     onedocker-cli test --config=<config> --package_name=<package_name> --cmd_args=<cmd_args> [--version=<version> --timeout=<timeout>][options]
     onedocker-cli show --config=<config> --package_name=<package_name> [--version=<version>] [options]
@@ -47,7 +47,6 @@ log_svc = None
 task_definition = None
 repository_path = None
 
-DEFAULT_BINARY_VERSION = "latest"
 DEFAULT_TIMEOUT = 18000
 
 
@@ -202,9 +201,7 @@ def main() -> None:
 
     package_name = arguments["--package_name"]
     package_path = arguments["--package_path"]
-    version = (
-        arguments["--version"] if arguments["--version"] else DEFAULT_BINARY_VERSION
-    )
+    version = arguments["--version"]
 
     config = yaml.load(Path(arguments["--config"])).get("onedocker-cli")
     task_definition = config["setting"]["task_definition"]

--- a/onedocker/tests/script/cli/test_onedocker_cli.py
+++ b/onedocker/tests/script/cli/test_onedocker_cli.py
@@ -10,7 +10,9 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import yaml
-from docopt import docopt
+
+# pyre-ignore[21]
+from docopt import docopt, DocoptExit
 from fbpcp.entity.container_instance import ContainerInstanceStatus
 from fbpcp.service.container_aws import AWSContainerService
 from fbpcp.service.log_cloudwatch import CloudWatchLogService
@@ -295,6 +297,26 @@ class TestOnedockerCli(unittest.TestCase):
         self.mockODPRUpload.assert_called_once_with(
             self.package_name, self.version, self.package_path
         )
+
+    def test_upload_throw_without_version(self):
+        # Arrange & Act
+        with self.assertRaises(DocoptExit):
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "onedocker-cli",
+                    "upload",
+                    "--config=" + self.config_file,
+                    "--package_name=" + self.package_name,
+                    "--package_path=" + self.package_path,
+                ],
+            ):
+                main()
+
+        # Assert
+        self.mockYamlLoad.assert_not_called()
+        self.mockODPRUpload.assert_not_called()
 
     def test_archive(self):
         # Arrange & Act


### PR DESCRIPTION
Summary: As part of the plan to retire the default binary version, we are not enforcing user of onedocker-cli to specify a version when uploading. There shouldn't be any backward compatibility issue here since we are enforcing the version to be set.

Differential Revision: D38922332

