### PR TITLE
Add container_type to ContainerService & AWSContainerService

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional
 from fbpcp.entity.cluster_instance import Cluster
 
 from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 
 
@@ -34,6 +35,7 @@ class ContainerService(abc.ABC):
         container_definition: str,
         cmd: str,
         env_vars: Optional[Dict[str, str]] = None,
+        container_type: Optional[ContainerType] = None,
     ) -> ContainerInstance:
         pass
 
@@ -43,6 +45,7 @@ class ContainerService(abc.ABC):
         container_definition: str,
         cmds: List[str],
         env_vars: Optional[Dict[str, str]] = None,
+        container_type: Optional[ContainerType] = None,
     ) -> List[ContainerInstance]:
         pass
 

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -154,9 +154,9 @@ class OneDockerService(MetricsGetter):
                 "task definition should be specified when spinning up containers"
             )
         containers = self.container_svc.create_instances(
-            task_definition,
-            cmds,
-            env_vars,
+            container_definition=task_definition,
+            cmds=cmds,
+            env_vars=env_vars,
         )
 
         if self.metrics:


### PR DESCRIPTION
Summary:
- Add container_type to ContainerService interface & AWSContainerService
- Use keyword args in OneDocker layer to prevent breaks

Differential Revision: D38727973

