### PR TITLE
Add support for resource in repo monitor

### DIFF
--- a/fbpcp/entity/policy_settings_config.py
+++ b/fbpcp/entity/policy_settings_config.py
@@ -22,9 +22,11 @@ class PolicySettingsConfig:
         effect: The specified effect.
         principal: The specified principal. Use normal string or "re(<principal regex>)" for regex matching.
         actions: List of specified actions.
+        resources: List of resources.
     """
 
     exist: bool
     effect: Effect
     principal: str
     actions: List[str]
+    resources: List[str]

--- a/fbpcp/service/policy_validation_aws.py
+++ b/fbpcp/service/policy_validation_aws.py
@@ -66,7 +66,7 @@ class AWSPolicyValidationService(PolicyValidationService):
                 rule.effect,
                 rule.principal,
                 rule.actions,
-                [f"arn:aws:s3:::{bucket}/*"],
+                rule.resources,
             ):
                 self.logger.error(
                     "The policy of bucket %s does not satisfy the following policy settings: %s.",

--- a/tests/service/test_policy_validation_aws.py
+++ b/tests/service/test_policy_validation_aws.py
@@ -10,21 +10,23 @@ from fbpcp.entity.policy_settings_config import Effect, PolicySettingsConfig
 from fbpcp.entity.policy_statement import PolicyStatement
 from fbpcp.service.policy_validation_aws import AWSPolicyValidationService
 
-TEST_ACTION = "s3:GetObject"
+TEST_ACTION_1 = "s3:GetObject"
+TEST_ACTION_2 = "s3:ListBucket"
 TEST_BUCKET = "onedocker-repo-test"
-TEST_RESOURCE = f"arn:aws:s3:::{TEST_BUCKET}/*"
+TEST_RESOURCE_1 = f"arn:aws:s3:::{TEST_BUCKET}/*"
+TEST_RESOURCE_2 = f"arn:aws:s3:::{TEST_BUCKET}"
 TEST_STATEMENT = [
     PolicyStatement(
         effect="Allow",
         principals=["*"],
-        actions=[TEST_ACTION],
-        resources=[TEST_RESOURCE],
+        actions=[TEST_ACTION_1],
+        resources=[TEST_RESOURCE_1],
     ),
     PolicyStatement(
         effect="Allow",
         principals=["arn:aws:iam::account-id:root"],
-        actions=[TEST_ACTION],
-        resources=[TEST_RESOURCE],
+        actions=[TEST_ACTION_2],
+        resources=[TEST_RESOURCE_2],
     ),
 ]
 
@@ -41,14 +43,16 @@ class TestAWSPolicyValidationService(unittest.TestCase):
                 exist=True,
                 effect=Effect.ALLOW.value,
                 principal="*",
-                actions=[TEST_ACTION],
+                actions=[TEST_ACTION_1],
+                resources=[TEST_RESOURCE_1],
             ),
             # Test regex principal
             PolicySettingsConfig(
                 exist=True,
                 effect=Effect.ALLOW.value,
                 principal="re(arn:aws:iam::account-id:.*)",
-                actions=[TEST_ACTION],
+                actions=[TEST_ACTION_2],
+                resources=[TEST_RESOURCE_2],
             ),
             # Test not exist policy
             PolicySettingsConfig(
@@ -56,6 +60,7 @@ class TestAWSPolicyValidationService(unittest.TestCase):
                 effect=Effect.ALLOW.value,
                 principal="re(.*)",
                 actions=["not-exist-action"],
+                resources=["non-existing-resource"],
             ),
         ]
         # Act
@@ -72,7 +77,15 @@ class TestAWSPolicyValidationService(unittest.TestCase):
                 exist=True,
                 effect=Effect.DENY.value,
                 principal="*",
-                actions=[TEST_ACTION],
+                actions=[TEST_ACTION_1],
+                resources=[TEST_RESOURCE_1],
+            ),
+            PolicySettingsConfig(
+                exist=True,
+                effect=Effect.ALLOW.value,
+                principal="re(arn:aws:iam::account-id:.*)",
+                actions=[TEST_ACTION_2],
+                resources=[TEST_RESOURCE_1],
             ),
         ]
         # Act


### PR DESCRIPTION
Summary: In policy statement we might want to specify different resources, this diffs allows for this flexibility to check resources in the policy

Differential Revision: D39061552

