### PR TITLE
Anonymously client in S3 Gateway

### DIFF
--- a/fbpcp/gateway/s3.py
+++ b/fbpcp/gateway/s3.py
@@ -11,7 +11,8 @@ import os
 from typing import Any, Dict, List, Optional
 
 import boto3
-from botocore.client import BaseClient
+from botocore import UNSIGNED
+from botocore.client import BaseClient, Config
 from botocore.exceptions import ClientError
 from fbpcp.decorator.error_handler import error_handler
 from fbpcp.entity.policy_statement import PolicyStatement, PublicAccessBlockConfig
@@ -29,8 +30,12 @@ class S3Gateway(AWSGateway):
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         session_token: Optional[str] = None,
+        # TODO: This is a short term solution. For long term, OneDocker Repository might need to take care.
+        unsigned_enabled: bool = False,
     ) -> None:
         super().__init__(region, access_key_id, access_key_data, config, session_token)
+        if unsigned_enabled:
+            self.config.update(config=Config(signature_version=UNSIGNED))
         self.client: BaseClient = boto3.client(
             "s3", region_name=self.region, **self.config
         )

--- a/fbpcp/service/storage_s3.py
+++ b/fbpcp/service/storage_s3.py
@@ -26,9 +26,15 @@ class S3StorageService(StorageService):
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         session_token: Optional[str] = None,
+        unsigned_enabled: bool = False,
     ) -> None:
         self.s3_gateway = S3Gateway(
-            region, access_key_id, access_key_data, config, session_token
+            region,
+            access_key_id,
+            access_key_data,
+            config,
+            session_token,
+            unsigned_enabled,
         )
 
     def read(self, filename: str) -> str:

--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -209,7 +209,14 @@ def _download_executables(
     exe_name = _parse_package_name(package_name)
     exe_local_path = executable_path + exe_name
     exe_s3_path = f"{repository_path}{package_name}/{version}/{exe_name}"
-    storage_svc = S3StorageService(S3Path(repository_path).region)
+    # TODO: This is a short term solution. For long term, OneDocker Repository might need to take care.
+    is_onedocker_package_unsigned_request = bool(
+        os.environ.get("ONEDOCKER_PACKAGE_UNSIGNED_REQUEST", False)
+    )
+    storage_svc = S3StorageService(
+        S3Path(repository_path).region,
+        unsigned_enabled=is_onedocker_package_unsigned_request,
+    )
     onedocker_repo_svc = OneDockerRepositoryService(storage_svc, repository_path)
     logger.info(f"Downloading package {package_name}: {version} from {exe_s3_path}")
     onedocker_repo_svc.download(package_name, version, exe_local_path)


### PR DESCRIPTION
Summary:
in GCP, we need GKE container to download binaries from S3 prod bucket. Right now the S3 bucket is public but s3 client still requires users to provide credentials, while GCP users don't have AWS credentials.

After the investigation, we found that we can configure the client to not perform the signing step.

Differential Revision: D39073719

