### PR TITLE
Release fbpcp to add container type in OneDocker & ContainerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.1] - 2022-08-30
+### Added
+- Add customized container type to OneDocker & ContainerService
+
 ## [0.3.0] - 2022-08-22
 ### Added
 - Add ContainerType enity for different types of containers

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.0",
+    version="0.3.1",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
At partner side, PCSContainerService cannot call create_instance() with container_type untill we release D39044499 (https://github.com/facebookresearch/fbpcp/commit/876c6feb4e3c4146d926f49e5b4658f82ae56118);

This diff releases it to fbpcp so pcs can call customized container

Reviewed By: zhuang-93

Differential Revision: D39155800

