### PR TITLE
Rename default container type to medium

### DIFF
--- a/fbpcp/entity/container_type.py
+++ b/fbpcp/entity/container_type.py
@@ -15,15 +15,15 @@ from fbpcp.error.pcp import InvalidParameterError
 
 
 class ContainerType(Enum):
-    DEFAULT = "DEFAULT"
-    LARGE = "LARGE"
     SMALL = "SMALL"
+    MEDIUM = "MEDIUM"
+    LARGE = "LARGE"
 
 
 CONTAINER_TYPES: Dict[CloudProvider, Dict[ContainerType, Dict[str, int]]] = {
     CloudProvider.AWS: {
         ContainerType.SMALL: {"cpu": 1, "memory": 8},
-        ContainerType.DEFAULT: {"cpu": 4, "memory": 30},
+        ContainerType.MEDIUM: {"cpu": 4, "memory": 30},
         ContainerType.LARGE: {"cpu": 16, "memory": 120},
     }
 }

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -34,7 +34,7 @@ TEST_CONTAINER_DEFNITION = "test-container-definition"
 TEST_ENV_VARS = {"k1": "v1", "k2": "v2"}
 TEST_CMD_1 = "test_1"
 TEST_CMD_2 = "test_2"
-TEST_CONTAINER_TYPE = ContainerType.DEFAULT
+TEST_CONTAINER_TYPE = ContainerType.MEDIUM
 TEST_CLOUD_PROVIDER = CloudProvider.AWS
 
 


### PR DESCRIPTION
Summary: We want to rename this because we received a suggestion that default is usually a naming for value, not for type: [comment link](https://fb.workplace.com/groups/164332244998024/posts/946702643427643/?comment_id=946746143423293)

Differential Revision: D39364976

