### PR TITLE
Release fbpcp to support skip container warm up in mpc service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.2] - 2022-09-19
+### Added
+- Add `wait_for_containers_to_start_up` (default True) in mpc service to support lazy container spin-up
+
 ## [0.3.1] - 2022-08-30
 ### Added
 - Add customized container type to OneDocker & ContainerService

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.1",
+    version="0.3.2",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
## Why
In the previous Diff stack, I'm adding skip comtainer start up support in mpc service. This is the bump PyPi release to 0.3.2
## What
* Bump PyPi to 0.3.2
* adding changelog

Reviewed By: ziqih

Differential Revision: D39629749

