### PR TITLE
Release fbpcp 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.3] - 2022-09-29
+### Removed
+- Remove self-signed certificate and core dump uploader functionalities from onedocker_runner
+
 ## [0.3.2] - 2022-09-19
 ### Added
 - Add `wait_for_containers_to_start_up` (default True) in mpc service to support lazy container spin-up

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.2",
+    version="0.3.3",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: Cut release fbpcp repo for onedocker image release

Reviewed By: jliu0501

Differential Revision: D39935936

