### PR TITLE
MPCService container start-up only retry failed containers

### DIFF
--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -337,3 +337,86 @@ class TestMPCService(IsolatedAsyncioTestCase):
             existing_container_completed,
             self.mpc_service._get_updated_container(None, existing_container_completed),
         )
+
+    def test_get_containers_to_start_no_existing_containers(self) -> None:
+        for num_containers in range(2):
+            with self.subTest(num_containers=num_containers):
+                containers_to_start = self.mpc_service.get_containers_to_start(
+                    num_containers
+                )
+                self.assertEqual(containers_to_start, list(range(num_containers)))
+
+    def test_get_containers_to_start_existing_containers(self) -> None:
+        for existing_statuses in (
+            (ContainerInstanceStatus.FAILED,),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.FAILED,
+            ),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.COMPLETED,
+            ),
+            (
+                ContainerInstanceStatus.STARTED,
+                ContainerInstanceStatus.FAILED,
+            ),
+        ):
+            # expect to start only the failed containers
+            expected_result = [
+                i
+                for i, status in enumerate(existing_statuses)
+                if status is ContainerInstanceStatus.FAILED
+            ]
+            with self.subTest(
+                existing_statuses=existing_statuses, expected_result=expected_result
+            ):
+                containers_to_start = self.mpc_service.get_containers_to_start(
+                    len(existing_statuses),
+                    [
+                        ContainerInstance("id", "ip", status)
+                        for status in existing_statuses
+                    ],
+                )
+                self.assertEqual(containers_to_start, expected_result)
+
+    def test_get_containers_to_start_invalid_args(self) -> None:
+        # expect failure because num of command arguments != number existing containers
+        with self.assertRaises(ValueError):
+            self.mpc_service.get_containers_to_start(
+                2,
+                [
+                    ContainerInstance("id", "ip", ContainerInstanceStatus.FAILED),
+                ],
+            )
+
+    def test_get_pending_containers(self) -> None:
+        for existing_statuses, containers_to_start in (
+            # no existing containers case
+            ((), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.FAILED), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.STARTED), [0]),
+            ((ContainerInstanceStatus.STARTED, ContainerInstanceStatus.FAILED), [1]),
+        ):
+            existing_containers = [
+                ContainerInstance(str(i), "ip", status)
+                for i, status in enumerate(existing_statuses)
+            ]
+            new_pending_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in containers_to_start
+            ]
+            expected_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in range(2)
+            ]
+
+            with self.subTest(
+                new_pending_containers=new_pending_containers,
+                containers_to_start=containers_to_start,
+                existing_containers=existing_containers,
+            ):
+                pending_containers = self.mpc_service.get_pending_containers(
+                    new_pending_containers, containers_to_start, existing_containers
+                )
+                self.assertEqual(pending_containers, expected_containers)


### PR DESCRIPTION
Summary:
## What

- MPCService now looks at the existing MPC Instance containers before starting new containers
- Only start containers if...
   a) it's the first time starting containers
   b) the containers previously failed

## Why

- It's this kind of month
  - S296317
  - S291746
  - S293193

- More details here: https://docs.google.com/document/d/1eb06oXmKlUPBucLI5aE86Zz8oM_elwJGq5vRUpAIOCQ/edit?usp=sharing

Differential Revision: D39943925

