### PR TITLE
Release MPCService container start-up only retry failed containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.4] - 2022-09-30
+### Changed
+- MPCService container start-up only retry failed containers
+
 ## [0.3.3] - 2022-09-29
 ### Removed
 - Remove self-signed certificate and core dump uploader functionalities from onedocker_runner

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.3",
+    version="0.3.4",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
## Why
- D39943925 (https://github.com/facebookresearch/fbpcp/commit/027142ef716075940e06f93c8a3367ba73ab56c9) MPCService now looks at the existing MPC Instance containers before starting new containers
- Only start containers if...
   a) it's the first time starting containers
   b) the containers previously failed

## What
* Bump PyPi to 0.3.3
* adding changelog

Differential Revision: D39953429

