### PR TITLE
Make describe_vpc_peering function more generic

### DIFF
--- a/fbpcp/entity/vpc_peering.py
+++ b/fbpcp/entity/vpc_peering.py
@@ -7,7 +7,7 @@
 # pyre-strict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 
 class VpcPeeringState(Enum):
@@ -29,4 +29,6 @@ class VpcPeering:
     role: VpcPeeringRole
     requester_vpc_id: str
     accepter_vpc_id: str
+    requester_cidr_block: Optional[str] = None
+    accepter_cidr_block: Optional[str] = None
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -214,13 +214,24 @@ def map_ec2vpcpeering_to_vpcpeering(
         status = VpcPeeringState.REJECTED
     requester_vpc_id = vpc_peering["RequesterVpcInfo"]["VpcId"]
     accepter_vpc_id = vpc_peering["AccepterVpcInfo"]["VpcId"]
+    requester_cidr_block = vpc_peering["RequesterVpcInfo"]["CidrBlock"]
+    accepter_cidr_block = vpc_peering["AccepterVpcInfo"]["CidrBlock"]
     role = (
         VpcPeeringRole.REQUESTER
         if requester_vpc_id == vpc_id
         else VpcPeeringRole.ACCEPTER
     )
     tags = convert_list_to_dict(vpc_peering.get("Tags"), "Key", "Value")
-    return VpcPeering(id, status, role, requester_vpc_id, accepter_vpc_id, tags)
+    return VpcPeering(
+        id,
+        status,
+        role,
+        requester_vpc_id,
+        accepter_vpc_id,
+        requester_cidr_block,
+        accepter_cidr_block,
+        tags,
+    )
 
 
 def map_ecstaskdefinition_to_containerdefinition(

--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -37,15 +37,17 @@ class EC2Gateway(AWSGateway):
     def describe_vpc_peering_connections_with_accepter_vpc_id(
         self,
         vpc_id: str,
-    ) -> Optional[VpcPeering]:
+    ) -> Optional[List[VpcPeering]]:
         filters = [
             {"Name": "accepter-vpc-info.vpc-id", "Values": [vpc_id]},
         ]
+
         response = self.client.describe_vpc_peering_connections(Filters=filters)
         return (
-            map_ec2vpcpeering_to_vpcpeering(
-                response["VpcPeeringConnections"][0], vpc_id
-            )
+            [
+                map_ec2vpcpeering_to_vpcpeering(vpc_conn, vpc_id)
+                for vpc_conn in response["VpcPeeringConnections"]
+            ]
             if response["VpcPeeringConnections"]
             else None
         )

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -19,6 +19,8 @@ class TestEC2Gateway(TestCase):
     TEST_ACCEPTER_VPC_ID = "vpc-12345"
     TEST_REQUESTER_VPC_ID = "vpc-56789"
     TEST_VPC_PEERING_ID = "pcx-77889900"
+    TEST_ACCEPTER_CIDR_BLOCK = "10.0.0.0/16"
+    TEST_REQUESTER_CIDR_BLOCK = "10.1.0.0/16"
 
     def setUp(self) -> None:
         self.aws_ec2 = MagicMock()
@@ -72,14 +74,14 @@ class TestEC2Gateway(TestCase):
             "VpcPeeringConnections": [
                 {
                     "AccepterVpcInfo": {
-                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlock": self.TEST_ACCEPTER_CIDR_BLOCK,
                         "CidrBlockSet": [{"CidrBlock": "10.0.0.0/16"}],
                         "OwnerId": self.TEST_AWS_ACCOUNT_ID,
                         "VpcId": self.TEST_ACCEPTER_VPC_ID,
                         "Region": self.REGION,
                     },
                     "RequesterVpcInfo": {
-                        "CidrBlock": "10.1.0.0/16",
+                        "CidrBlock": self.TEST_REQUESTER_CIDR_BLOCK,
                         "CidrBlockSet": [{"CidrBlock": "10.1.0.0/16"}],
                         "OwnerId": self.TEST_AWS_ACCOUNT_ID,
                         "VpcId": self.TEST_REQUESTER_VPC_ID,
@@ -100,6 +102,8 @@ class TestEC2Gateway(TestCase):
             role=VpcPeeringRole.ACCEPTER,
             requester_vpc_id=self.TEST_REQUESTER_VPC_ID,
             accepter_vpc_id=self.TEST_ACCEPTER_VPC_ID,
+            requester_cidr_block=self.TEST_REQUESTER_CIDR_BLOCK,
+            accepter_cidr_block=self.TEST_ACCEPTER_CIDR_BLOCK,
         )
 
         # Act

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -110,7 +110,7 @@ class TestEC2Gateway(TestCase):
         vpc_peering_connection = (
             self.ec2.describe_vpc_peering_connections_with_accepter_vpc_id(
                 vpc_id=self.TEST_ACCEPTER_VPC_ID
-            )
+            )[0]
         )
 
         # Assert

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -146,13 +146,15 @@ class ValidationSuite:
             vpc_peering = pce.pce_network.vpc_peering
         else:
             vpc = pce.pce_network.vpc
-            vpc_peering = (
+            vpc_peering_list = (
                 self.ec2_gateway.describe_vpc_peering_connections_with_accepter_vpc_id(
                     vpc_id=vpc.vpc_id
                 )
                 if vpc
                 else None
             )
+
+            vpc_peering = vpc_peering_list[0] if vpc_peering_list else None
 
         if not vpc_peering:
             return ValidationResult(

--- a/tests/gateway/test_ec2.py
+++ b/tests/gateway/test_ec2.py
@@ -238,6 +238,8 @@ class TestEC2Gateway(unittest.TestCase):
                 VpcPeeringRole.REQUESTER,
                 test_requester_vpc_id,
                 test_accepter_vpc_id,
+                TEST_CIDR_BLOCK,
+                TEST_CIDR_BLOCK,
             ),
         ]
         self.assertEqual(vpc_peerings, expected_vpc_peerings)


### PR DESCRIPTION
Summary:
This diff is to make the `describe_vpc_peering_connections_with_accepter_vpc_id` more generic so that it can also be used by vpc peering workflow.

Why need this change
- The current function only returns the first vpc peering connection for a given vpc id;
- It is possible for a VPC to received multiple peering connections, so it returns a list.

The use case of this function can be found D39974704

Reviewed By: karanluthra, ajaybhargavb

Differential Revision: D39974618

