### PR TITLE
Extend VpcPeering Object to include cidr for both sides

### DIFF
--- a/fbpcp/entity/vpc_peering.py
+++ b/fbpcp/entity/vpc_peering.py
@@ -7,7 +7,7 @@
 # pyre-strict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 
 class VpcPeeringState(Enum):
@@ -29,4 +29,6 @@ class VpcPeering:
     role: VpcPeeringRole
     requester_vpc_id: str
     accepter_vpc_id: str
+    requester_vpc_cidr: Optional[str] = None
+    accepter_vpc_cidr: Optional[str] = None
     tags: Dict[str, str] = field(default_factory=dict)

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -214,13 +214,24 @@ def map_ec2vpcpeering_to_vpcpeering(
         status = VpcPeeringState.REJECTED
     requester_vpc_id = vpc_peering["RequesterVpcInfo"]["VpcId"]
     accepter_vpc_id = vpc_peering["AccepterVpcInfo"]["VpcId"]
+    requester_vpc_cidr = vpc_peering["RequesterVpcInfo"]["CidrBlock"]
+    accepter_vpc_cidr = vpc_peering["AccepterVpcInfo"]["CidrBlock"]
     role = (
         VpcPeeringRole.REQUESTER
         if requester_vpc_id == vpc_id
         else VpcPeeringRole.ACCEPTER
     )
     tags = convert_list_to_dict(vpc_peering.get("Tags"), "Key", "Value")
-    return VpcPeering(id, status, role, requester_vpc_id, accepter_vpc_id, tags)
+    return VpcPeering(
+        id,
+        status,
+        role,
+        requester_vpc_id,
+        accepter_vpc_id,
+        requester_vpc_cidr,
+        accepter_vpc_cidr,
+        tags,
+    )
 
 
 def map_ecstaskdefinition_to_containerdefinition(

--- a/pce/gateway/tests/test_ec2.py
+++ b/pce/gateway/tests/test_ec2.py
@@ -19,6 +19,8 @@ class TestEC2Gateway(TestCase):
     TEST_ACCEPTER_VPC_ID = "vpc-12345"
     TEST_REQUESTER_VPC_ID = "vpc-56789"
     TEST_VPC_PEERING_ID = "pcx-77889900"
+    TEST_ACCEPTER_CIDR_BLOCK = "10.0.0.0/16"
+    TEST_REQUESTER_CIDR_BLOCK = "10.1.0.0/16"
 
     def setUp(self) -> None:
         self.aws_ec2 = MagicMock()
@@ -72,14 +74,14 @@ class TestEC2Gateway(TestCase):
             "VpcPeeringConnections": [
                 {
                     "AccepterVpcInfo": {
-                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlock": self.TEST_ACCEPTER_CIDR_BLOCK,
                         "CidrBlockSet": [{"CidrBlock": "10.0.0.0/16"}],
                         "OwnerId": self.TEST_AWS_ACCOUNT_ID,
                         "VpcId": self.TEST_ACCEPTER_VPC_ID,
                         "Region": self.REGION,
                     },
                     "RequesterVpcInfo": {
-                        "CidrBlock": "10.1.0.0/16",
+                        "CidrBlock": self.TEST_REQUESTER_CIDR_BLOCK,
                         "CidrBlockSet": [{"CidrBlock": "10.1.0.0/16"}],
                         "OwnerId": self.TEST_AWS_ACCOUNT_ID,
                         "VpcId": self.TEST_REQUESTER_VPC_ID,
@@ -100,6 +102,8 @@ class TestEC2Gateway(TestCase):
             role=VpcPeeringRole.ACCEPTER,
             requester_vpc_id=self.TEST_REQUESTER_VPC_ID,
             accepter_vpc_id=self.TEST_ACCEPTER_VPC_ID,
+            requester_vpc_cidr=self.TEST_REQUESTER_CIDR_BLOCK,
+            accepter_vpc_cidr=self.TEST_ACCEPTER_CIDR_BLOCK,
         )
 
         # Act

--- a/tests/gateway/test_ec2.py
+++ b/tests/gateway/test_ec2.py
@@ -238,6 +238,8 @@ class TestEC2Gateway(unittest.TestCase):
                 VpcPeeringRole.REQUESTER,
                 test_requester_vpc_id,
                 test_accepter_vpc_id,
+                TEST_CIDR_BLOCK,
+                TEST_CIDR_BLOCK,
             ),
         ]
         self.assertEqual(vpc_peerings, expected_vpc_peerings)


### PR DESCRIPTION
Summary: Extend the VpcPeering class to encapsulate cidr as the the VPC peering requires the requester's cidr to update the route table. Set the cidr optional because the current GCP workflow will not return these value (and it was not needed for peering vpc on the GCP).

Reviewed By: ajaybhargavb

Differential Revision: D40047134

