### PR TITLE
Implement function to accept vpc peering

### DIFF
--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -214,8 +214,8 @@ def map_ec2vpcpeering_to_vpcpeering(
         status = VpcPeeringState.REJECTED
     requester_vpc_id = vpc_peering["RequesterVpcInfo"]["VpcId"]
     accepter_vpc_id = vpc_peering["AccepterVpcInfo"]["VpcId"]
-    requester_vpc_cidr = vpc_peering["RequesterVpcInfo"]["CidrBlock"]
-    accepter_vpc_cidr = vpc_peering["AccepterVpcInfo"]["CidrBlock"]
+    requester_vpc_cidr = vpc_peering["RequesterVpcInfo"].get("CidrBlock", None)
+    accepter_vpc_cidr = vpc_peering["AccepterVpcInfo"].get("CidrBlock", None)
     role = (
         VpcPeeringRole.REQUESTER
         if requester_vpc_id == vpc_id

--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -8,6 +8,7 @@
 from typing import Any, Dict, List, Optional
 
 import boto3
+from fbpcp.decorator.error_handler import error_handler
 from fbpcp.entity.vpc_peering import VpcPeering
 from fbpcp.gateway.aws import AWSGateway
 from fbpcp.mapper.aws import map_ec2vpcpeering_to_vpcpeering
@@ -49,5 +50,20 @@ class EC2Gateway(AWSGateway):
                 for vpc_conn in response["VpcPeeringConnections"]
             ]
             if response["VpcPeeringConnections"]
+            else None
+        )
+
+    @error_handler
+    def accept_vpc_peering_connection(
+        self, vpc_peering_connection_id: str, vpc_id: str
+    ) -> Optional[VpcPeering]:
+
+        response = self.client.accept_vpc_peering_connection(
+            VpcPeeringConnectionId=vpc_peering_connection_id
+        )
+
+        return (
+            map_ec2vpcpeering_to_vpcpeering(response["VpcPeeringConnection"], vpc_id)
+            if response["VpcPeeringConnection"]
             else None
         )


### PR DESCRIPTION
Summary:
- Create the function to accept vpc peering by the given connection id and vpc id.
- This diff also improves the mapper to better handle the `deleted` vpc connection which doesn't have cidr.

Reviewed By: ajaybhargavb

Differential Revision: D39974662

