### PR TITLE
Adding command line arg to run specific PCE validations

### DIFF
--- a/pce/validator/tests/validator_tests.py
+++ b/pce/validator/tests/validator_tests.py
@@ -980,8 +980,8 @@ class TestValidationStepSkipping(TestCase):
         # arrange
         self._mock_all_validate_methods()
         skip_steps = [ValidationStepNames.VPC_CIDR, ValidationStepNames.LOG_GROUP]
-        filtered_validation_steps = filter(
-            lambda step: step not in skip_steps, ValidationStepNames
+        filtered_validation_steps = list(
+            filter(lambda step: step not in skip_steps, ValidationStepNames)
         )
         # act
         _ = self.validator.validate_network_and_compute(
@@ -997,3 +997,18 @@ class TestValidationStepSkipping(TestCase):
         # assert: skipped validate_* methods not called
         self.validator.validate_vpc_cidr.assert_not_called()
         self.validator.validate_log_group.assert_not_called()
+
+    def test_multiple_run_steps(self) -> None:
+        # arrange
+        self._mock_all_validate_methods()
+        run_steps = [ValidationStepNames.SUBNETS, ValidationStepNames.FIREWALL]
+        # act
+        _ = self.validator.validate_network_and_compute(self.pce, run_steps=run_steps)
+
+        # assert: correct validate_* methods called
+        self.validator.validate_subnets.assert_called_once()
+        self.validator.validate_firewall.assert_called_once()
+
+        # assert: other validate_* methods not called
+        self.validator.validate_vpc_peering.assert_not_called()
+        self.validator.validate_route_table.assert_not_called()

--- a/pce/validator/validation_suite.py
+++ b/pce/validator/validation_suite.py
@@ -7,10 +7,11 @@
 # pyre-strict
 
 import ipaddress
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
 from fbpcp.entity.firewall_ruleset import FirewallRuleset
@@ -487,16 +488,29 @@ class ValidationSuite:
         )
 
     def validate_network_and_compute(
-        self, pce: PCE, skip_steps: Optional[List[ValidationStepNames]] = None
+        self,
+        pce: PCE,
+        skip_steps: Optional[List[ValidationStepNames]] = None,
+        run_steps: Optional[List[ValidationStepNames]] = None,
     ) -> List[ValidationResult]:
         """
         Execute all existing validations returning warnings and errors encapsulated in `ValidationResult` objects
         """
-        validation_steps: Iterable[ValidationStepNames] = list(ValidationStepNames)
+        validation_steps: List[ValidationStepNames] = (
+            run_steps if run_steps else list(ValidationStepNames)
+        )
         if skip_steps:
-            validation_steps = filter(
-                lambda step: step not in skip_steps, validation_steps
+            validation_steps = list(
+                filter(lambda step: step not in skip_steps, validation_steps)
             )
+            logging.info(
+                f"Skipping the following validation steps: {', '.join([step.code_name for step in skip_steps])}"
+            )
+
+        logging.info(
+            f"Running the following validation steps: {', '.join([step.code_name for step in validation_steps])}"
+        )
+
         with click.progressbar(
             [
                 (


### PR DESCRIPTION
Summary: This diff provides a way to run only certain PCE validations using the `--run-step` on PCE validator. Also logs skipped and to be run validations.

Reviewed By: karanluthra

Differential Revision: D40193570

