### PR TITLE
Improve the mapping for peering status

### DIFF
--- a/fbpcp/entity/vpc_peering.py
+++ b/fbpcp/entity/vpc_peering.py
@@ -13,8 +13,9 @@ from typing import Dict, Optional
 class VpcPeeringState(Enum):
     PENDING_ACCEPTANCE = "PENDING_ACCEPTANCE"
     ACTIVE = "ACTIVE"
-    REJECTED = "REJECTED"
-    NOT_READY = "NOT_READY"
+    INACTIVE = "INACTIVE"
+    PROVISIONING = "PROVISIONING"
+    INITIATING = "INITIATING"
 
 
 class VpcPeeringRole(Enum):

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -204,14 +204,16 @@ def map_ec2vpcpeering_to_vpcpeering(
     vpc_peering: Dict[str, Any], vpc_id: str
 ) -> VpcPeering:
     id = vpc_peering["VpcPeeringConnectionId"]
-    status = VpcPeeringState.NOT_READY
+    status = VpcPeeringState.INACTIVE
     status_code = vpc_peering["Status"]["Code"]
     if status_code == "active":
         status = VpcPeeringState.ACTIVE
     elif status_code == "pending-acceptance":
         status = VpcPeeringState.PENDING_ACCEPTANCE
-    elif status_code == "rejected":
-        status = VpcPeeringState.REJECTED
+    elif status_code == "provisioning":
+        status = VpcPeeringState.PROVISIONING
+    elif status_code == "initiating-request":
+        status = VpcPeeringState.INITIATING
     requester_vpc_id = vpc_peering["RequesterVpcInfo"]["VpcId"]
     accepter_vpc_id = vpc_peering["AccepterVpcInfo"]["VpcId"]
     requester_vpc_cidr = vpc_peering["RequesterVpcInfo"].get("CidrBlock", None)


### PR DESCRIPTION
Summary:
The current mapping is not sufficient to describe the immediate vpc peering status from a related API call. And the `provisioning` is mapped to `NOT_READY` with `failed`, `deleted`, `deleting`, and `expire` which complicates the logic to check the success of the peering. The `provisioning` status after acceptance only lasts for a very short period (test: D40107684) but it is a state prior to `active` indicating the acceptance is successful. Therefore, we separated the `provisioning` and use `inactive` to represent the 'unsuccessful' status.

The new mapping:

AWS:
```
Pending-acceptance -> pending_acceptance
Provisioning -> not_ready
Active -> active
Failed, expired, rejected, deleted, deleting -> inactive
Initiating-request -> initiating
```

GCP
```
Active -> active
Else -> inactive
```

{F778655190}

Ref: https://fburl.com/2oubduyj (AWS)
https://fburl.com/bmpd74ex (GCP)

Reviewed By: ajaybhargavb

Differential Revision: D40152913

