### PR TITLE
Add replace route function

### DIFF
--- a/pce/gateway/ec2.py
+++ b/pce/gateway/ec2.py
@@ -80,3 +80,14 @@ class EC2Gateway(AWSGateway):
         )
 
         return response["Return"]
+
+    @error_handler
+    def replace_route(
+        self, route_table_id: str, vpc_peering_connection_id: str, dest_cidr: str
+    ) -> None:
+
+        self.client.replace_route(
+            RouteTableId=route_table_id,
+            DestinationCidrBlock=dest_cidr,
+            VpcPeeringConnectionId=vpc_peering_connection_id,
+        )


### PR DESCRIPTION
Summary: Added a new function to replace the route for vpc peering when the `cidr` exists.

Reviewed By: ajaybhargavb

Differential Revision: D40724962

