### PR TITLE
add server_uris to MPCInstance

### DIFF
--- a/fbpcp/entity/mpc_instance.py
+++ b/fbpcp/entity/mpc_instance.py
@@ -37,6 +37,7 @@ class MPCInstance:
     containers: List[ContainerInstance]
     status: MPCInstanceStatus
     game_args: Optional[List[Dict[str, Any]]]
+    server_uris: Optional[List[str]] = None
 
     def get_instance_id(self) -> str:
         return self.instance_id

--- a/fbpcp/service/mpc.py
+++ b/fbpcp/service/mpc.py
@@ -117,6 +117,7 @@ class MPCService:
             [],
             MPCInstanceStatus.CREATED,
             game_args,
+            [],
         )
 
         self.instance_repository.create(instance)

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -64,6 +64,7 @@ class TestMPCService(IsolatedAsyncioTestCase):
             [],
             MPCInstanceStatus.CREATED,
             GAME_ARGS,
+            [],
         )
 
     @staticmethod
@@ -77,6 +78,7 @@ class TestMPCService(IsolatedAsyncioTestCase):
             [],
             MPCInstanceStatus.CREATED,
             GAME_ARGS,
+            [],
         )
 
     @staticmethod
@@ -90,6 +92,7 @@ class TestMPCService(IsolatedAsyncioTestCase):
             [],
             MPCInstanceStatus.CREATED,
             GAME_ARGS,
+            [],
         )
 
     async def test_spin_up_containers_onedocker_inconsistent_arguments(self):


### PR DESCRIPTION
Summary:
To establish TLS connection, we need to route each container's ip_address to a server_hostname/server_uri. Each container should be assigned with a unique server uris.

Additional context:
Certificates are generated with the domain of this server_uris and supports multiple subdomains. We need a different address for every node because eventually we will expect the nodes to be looked up via DNS.

Differential Revision: D40917008

