### PR TITLE
Releasing fbpcp 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.5] - 2022-11-02
+### Changed
+- New field server_uris added to MPCInstance
+
 ## [0.3.4] - 2022-09-30
 ### Changed
 - MPCService container start-up only retry failed containers

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.4",
+    version="0.3.5",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: We need to release the change in D40917008 (https://github.com/facebookresearch/fbpcp/commit/8de14e02901cc18cacf097e266e4da5e9482c3f3) in fbpcp, in order for us to make changes in fbpcs in D40906402.

Differential Revision: D40948331

