### PR TITLE
Freeze FBPCP mpc.py & test_mpc.py changes

### DIFF
--- a/tests/service/test_mpc_do_not_change.py
+++ b/tests/service/test_mpc_do_not_change.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#############################################################################
+# This test file is a short-term to freeze the file change during migration.
+# After migration completed, we shall delete this ut test
+# TODO: T137598681 clean up FBPCS mpc related files after migration complete
+#############################################################################
+import hashlib
+import inspect
+import unittest
+
+from fbpcp.service.mpc import MPCService
+
+from .test_mpc import TestMPCService
+
+NO_CHANGE_FILES = (
+    {
+        "cls": MPCService,
+        "file_md5": "35dbe2a73b1016d6d631b03abc612929",
+    },
+    {
+        "cls": TestMPCService,
+        "file_md5": "6a1c7a74f28d164e113b68dbcab29962",
+    },
+)
+
+
+class TestMPCDontChange(unittest.TestCase):
+    def test_mpc_service_no_change(self):
+        for no_change_file in NO_CHANGE_FILES:
+            cls_name = no_change_file["cls"]
+            file_name = inspect.getfile(cls_name)
+            self.assertEqual(
+                no_change_file["file_md5"],
+                self.gen_file_md5(file_name),
+                msg=f"assertion on file: {file_name}",
+            )
+
+    def gen_file_md5(self, file_name):
+        with open(file_name, "rb") as file_to_check:
+            data = file_to_check.read()
+            # pipe contents of the file through
+            return hashlib.md5(data).hexdigest()


### PR DESCRIPTION
Summary:
## Why
In next couple weeks, I'm going to migrate mpc service from fbpcp to fbpcs.
This is the first guard to avoid any further changes in fbpcp's mpc realted files
detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

## What
- adding `test_mpc_do_not_change.py` to enforce code change freeze
- check with file md5has

## Plan
1. migrate mpc service from fbpcp to fbpcs (this diff)
2. migrate mpc instance from fbpcp to fbpcs

Differential Revision: D41140348

