### PR TITLE
Freeze FBPCP mpc_game_config.py changes

### DIFF
--- a/tests/service/test_mpc_do_not_change.py
+++ b/tests/service/test_mpc_do_not_change.py
@@ -13,6 +13,9 @@ import hashlib
 import inspect
 import unittest
 
+from fbpcp.entity.mpc_game_config import MPCGameConfig
+from fbpcp.repository.mpc_game_repository import MPCGameRepository
+
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.mpc_game import MPCGameService
 
@@ -35,6 +38,14 @@ NO_CHANGE_FILES = (
     {
         "cls": TestMPCGameService,
         "file_md5": "e1e4517471ff5630a7a7dc5db645ed5f",
+    },
+    {
+        "cls": MPCGameConfig,
+        "file_md5": "39326c1de0bb8795313ce84560d25c97",
+    },
+    {
+        "cls": MPCGameRepository,
+        "file_md5": "d2d09421e3ab8c612a2208d7a0269996",
     },
 )
 


### PR DESCRIPTION
Summary:
## Why
In next couple weeks, I'm going to migrate mpc service from fbpcp to fbpcs.
This is the first guard to avoid any further changes in fbpcp's mpc realted files
detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

## What
- added `test_mpc_do_not_change.py` to enforce code change freeze
- adding `mpc_game_config.py` in do not change list

Differential Revision: D41200589

