### PR TITLE
Freeze FBPCP MPCInstance/MPCInstanceRepository changes

### DIFF
--- a/tests/service/test_mpc_do_not_change.py
+++ b/tests/service/test_mpc_do_not_change.py
@@ -14,8 +14,10 @@ import inspect
 import unittest
 
 from fbpcp.service.mpc import MPCService
+from fbpcp.service.mpc_game import MPCGameService
 
 from .test_mpc import TestMPCService
+from .test_mpc_game import TestMPCGameService
 
 NO_CHANGE_FILES = (
     {
@@ -25,6 +27,14 @@ NO_CHANGE_FILES = (
     {
         "cls": TestMPCService,
         "file_md5": "6a1c7a74f28d164e113b68dbcab29962",
+    },
+    {
+        "cls": MPCGameService,
+        "file_md5": "36a2142e36759e382855e970f12c7403",
+    },
+    {
+        "cls": TestMPCGameService,
+        "file_md5": "e1e4517471ff5630a7a7dc5db645ed5f",
     },
 )
 

--- a/tests/service/test_mpc_do_not_change.py
+++ b/tests/service/test_mpc_do_not_change.py
@@ -13,6 +13,9 @@ import hashlib
 import inspect
 import unittest
 
+from fbpcp.entity.mpc_game_config import MPCGameConfig
+from fbpcp.repository.mpc_game_repository import MPCGameRepository
+
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.mpc_game import MPCGameService
 
@@ -35,6 +38,14 @@ NO_CHANGE_FILES = (
     {
         "cls": TestMPCGameService,
         "file_md5": "e1e4517471ff5630a7a7dc5db645ed5f",
+    },
+    {
+        "cls": MPCGameConfig,
+        "file_md5": "39326c1de0bb8795313ce84560d25c97",
+    },
+    {
+        "cls": MPCGameRepository,
+        "file_md5": "d2d09421e3ab8c612a2208d7a0269996",
     },
 )
 

--- a/tests/service/test_mpc_do_not_change.py
+++ b/tests/service/test_mpc_do_not_change.py
@@ -14,7 +14,9 @@ import inspect
 import unittest
 
 from fbpcp.entity.mpc_game_config import MPCGameConfig
+from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
+from fbpcp.repository.mpc_instance import MPCInstanceRepository
 
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.mpc_game import MPCGameService
@@ -46,6 +48,14 @@ NO_CHANGE_FILES = (
     {
         "cls": MPCGameRepository,
         "file_md5": "d2d09421e3ab8c612a2208d7a0269996",
+    },
+    {
+        "cls": MPCInstance,
+        "file_md5": "4a52cc896d438cb8900649265eb46b71",
+    },
+    {
+        "cls": MPCInstanceRepository,
+        "file_md5": "251b27ef762c7421a43fe1e8062ce86b",
     },
 )
 


### PR DESCRIPTION
Summary:
## Why
In next couple weeks, I'm going to migrate mpc service from fbpcp to fbpcs.
This is the first guard to avoid any further changes in fbpcp's mpc realted files
detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

## What
- added `MPCInstanceRepository` to enforce code change freeze
- adding `MPCInstance` in do not change list

Reviewed By: YigeZhu

Differential Revision: D41203534

