### PR TITLE
OSS OneDocker metadata service

### DIFF
--- a/onedocker/entity/measurement.py
+++ b/onedocker/entity/measurement.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass
+
+from enum import Enum
+
+from dataclasses_json import dataclass_json
+
+
+class MeasurementType(Enum):
+    # TODO These types are not finalized yet, only adding few to test the integration.
+    # TODO will update/add later when developing measurement service
+    MD5 = "MD5"
+    SHA256 = "SHA256"
+
+    @classmethod
+    def has_member(cls, name: str) -> bool:
+        return name in cls.__members__
+
+
+@dataclass_json
+@dataclass
+class Measurement:
+    key: MeasurementType
+    value: str

--- a/onedocker/entity/metadata.py
+++ b/onedocker/entity/metadata.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from onedocker.entity.measurement import MeasurementType
+
+
+@dataclass
+class PackageMetadata:
+    package_name: str
+    version: str
+    measurements: Dict[MeasurementType, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "package_name": self.package_name,
+            "version": self.version,
+            "measurements": {k.value: v for k, v in self.measurements.items()},
+        }

--- a/onedocker/gateway/dynamodb.py
+++ b/onedocker/gateway/dynamodb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, Optional
+
+import boto3
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from botocore.exceptions import ClientError
+from fbpcp.decorator.error_handler import error_handler
+from fbpcp.error.pcp import PcpError
+from fbpcp.gateway.aws import AWSGateway
+
+
+class DynamoDBGateway(AWSGateway):
+    def __init__(
+        self,
+        region: str,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(region, access_key_id, access_key_data, config)
+        # pyre-ignore
+        self.client = boto3.client("dynamodb", region_name=self.region, **self.config)
+        self.serializer = TypeSerializer()
+        self.deserializer = TypeDeserializer()
+
+    @error_handler
+    def put_item(self, table_name: str, item: Dict[str, Any]) -> None:
+        dynamo_item = {k: self.serializer.serialize(v) for k, v in item.items()}
+        try:
+            self.client.put_item(
+                TableName=table_name,
+                Item=dynamo_item,
+                ConditionExpression="attribute_not_exists(instance_id)",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise PcpError(
+                    "Cannot put item, an item with the given instance_id already exists"
+                )
+            raise e
+
+    @error_handler
+    def get_item(
+        self,
+        table_name: str,
+        key_name: str,
+        # pyre-ignore
+        key_value: Any,
+    ) -> Dict[str, Any]:
+        key = {key_name: self.serializer.serialize(key_value)}
+        raw_response = self.client.get_item(
+            TableName=table_name,
+            Key=key,
+        )
+        if "Item" not in raw_response:
+            raise PcpError(f"No item in database for key {key_name}: {key_value}")
+        return {
+            k: self.deserializer.deserialize(v) for k, v in raw_response["Item"].items()
+        }
+
+    @error_handler
+    def update_item(
+        self,
+        table_name: str,
+        key_name: str,
+        # pyre-ignore
+        key_value: Any,
+        attribute_name: str,
+        # pyre-ignore
+        new_value: Any,
+    ) -> None:
+        update_expression = f"SET {attribute_name} = :new_data"
+        expression_attributes = {":new_data": new_value}
+        boto3_key = {key_name: self.serializer.serialize(key_value)}
+        boto3_attributes = {
+            k: self.serializer.serialize(v) for k, v in expression_attributes.items()
+        }
+        try:
+            self.client.update_item(
+                TableName=table_name,
+                Key=boto3_key,
+                UpdateExpression=update_expression,
+                ExpressionAttributeValues=boto3_attributes,
+                ConditionExpression="attribute_exists(instance_id)",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                raise PcpError(
+                    "Cannot get item, an item with the given instance_id does not already exist"
+                )
+            raise e
+
+    @error_handler
+    def delete_item(
+        self,
+        table_name: str,
+        key_name: str,
+        # pyre-ignore
+        key_value: Any,
+    ) -> None:
+        boto3_key = {key_name: self.serializer.serialize(key_value)}
+        self.client.delete_item(TableName=table_name, Key=boto3_key)

--- a/onedocker/mapper/aws.py
+++ b/onedocker/mapper/aws.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Any, Dict
+
+from onedocker.entity.measurement import MeasurementType
+
+from onedocker.entity.metadata import PackageMetadata
+
+
+def map_dynamodbitem_to_packagemetadata(
+    dynamodb_item: Dict[str, Any]
+) -> PackageMetadata:
+    measurements = {
+        MeasurementType(key): value
+        for key, value in dynamodb_item.get("measurements", {}).items()
+    }
+    return PackageMetadata(
+        package_name=dynamodb_item.get("package_name"),
+        version=dynamodb_item.get("version"),
+        measurements=measurements,
+    )

--- a/onedocker/service/metadata.py
+++ b/onedocker/service/metadata.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, Optional
+
+from onedocker.entity.metadata import PackageMetadata
+from onedocker.gateway.dynamodb import DynamoDBGateway
+from onedocker.mapper.aws import map_dynamodbitem_to_packagemetadata
+
+
+class MetadataService:
+    def __init__(
+        self,
+        region: str,
+        table_name: str,
+        key_name: str,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.table_name = table_name
+        self.key_name = key_name
+        self.dynamodb_gateway = DynamoDBGateway(
+            region, access_key_id, access_key_data, config
+        )
+
+    def _build_key(self, package_name: str, version: str) -> str:
+        return f"{package_name}#{version}"
+
+    def get_medadata(self, package_name: str, version: str) -> PackageMetadata:
+        dynamodb_item = self.dynamodb_gateway.get_item(
+            table_name=self.table_name,
+            key_name=self.key_name,
+            key_value=self._build_key(package_name=package_name, version=version),
+        )
+
+        return map_dynamodbitem_to_packagemetadata(dynamodb_item=dynamodb_item)
+
+    def put_metadata(self, metadata: PackageMetadata) -> None:
+        md_dict = metadata.to_dict()
+        md_dict.update(
+            {self.key_name: self._build_key(metadata.package_name, metadata.version)}
+        )
+        self.dynamodb_gateway.put_item(table_name=self.table_name, item=md_dict)

--- a/onedocker/tests/gateway/test_dynamodb.py
+++ b/onedocker/tests/gateway/test_dynamodb.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+
+from onedocker.gateway.dynamodb import DynamoDBGateway
+
+
+class TestDynamoGateway(unittest.TestCase):
+    TEST_ACCESS_KEY_ID = "test-access-key-id"
+    TEST_ACCESS_KEY_DATA = "test-access-key-data"
+    TEST_REGION = "us-west-2"
+    TEST_TABLE_NAME = "test_table"
+
+    @patch("boto3.client")
+    def setUp(self, BotoClient) -> None:
+        self.gw = DynamoDBGateway(
+            self.TEST_REGION, self.TEST_ACCESS_KEY_ID, self.TEST_ACCESS_KEY_DATA
+        )
+        self.gw.client = BotoClient()
+        self.serializer = TypeSerializer()
+        self.deserializer = TypeDeserializer()
+
+    def test_put_item(self) -> None:
+        # Arrange
+        test_key_name = "instance_id"
+        test_key_value = "111"
+        test_attribute_name = "instance_name"
+        test_attribute_value = "test"
+        test_item = {
+            test_key_name: test_key_value,
+            test_attribute_name: test_attribute_value,
+        }
+        expected_item = {
+            test_key_name: {"S": test_key_value},
+            test_attribute_name: {"S": test_attribute_value},
+        }
+
+        # Act
+        self.gw.put_item(self.TEST_TABLE_NAME, test_item)
+
+        # Assert
+        self.gw.client.put_item.assert_called_with(
+            TableName=self.TEST_TABLE_NAME,
+            Item=expected_item,
+            ConditionExpression="attribute_not_exists(instance_id)",
+        )
+
+    def test_get_item(self) -> None:
+        # Arrange
+        test_key_name = "instance_id"
+        test_key_value = "111"
+        test_attribute_name = "instance_name"
+        test_attribute_value = "test"
+        client_return = {
+            "Item": {
+                test_key_name: {"S": test_key_value},
+                test_attribute_name: {"S": test_attribute_value},
+            },
+            "ResponseMetadata": {
+                "RequestId": "JSSDCD5NEGJ5VBSI7QO36GENVRVV4KQNSO5AEMVJF66Q9ASUAAJG",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "server": "Server",
+                    "date": "Mon, 22 Aug 2022 17:15:26 GMT",
+                    "content-type": "application/x-amz-json-1.0",
+                    "x-amzn-requestid": "JSSDCD5NEGJ5VBSI7QO36GENVRVV4KQNSO5AEMVJF66Q9ASUAAJG",
+                    "x-amz-crc32": "2917446620",
+                    "via": "HTTP/1.1 52.94.28.254:443 (fwdproxy2/234c392404618314ed5316cce89d49ae 66.220.149.19)",
+                    "x-connected-to": "52.94.28.254",
+                    "x-fb-ip-type": "allow_default",
+                    "connection": "keep-alive",
+                    "content-length": "85",
+                },
+                "RetryAttempts": 0,
+            },
+        }
+        expected_return = {
+            test_key_name: test_key_value,
+            test_attribute_name: test_attribute_value,
+        }
+        self.gw.client.get_item = MagicMock(return_value=client_return)
+
+        # Act
+        res = self.gw.get_item(
+            table_name=self.TEST_TABLE_NAME,
+            key_name=test_key_name,
+            key_value=test_key_value,
+        )
+
+        # Assert
+        self.assertEqual(res, expected_return)
+
+    def test_delete_item(self) -> None:
+        # Arrange
+        test_key_name = "instance_id"
+        test_key_value = "111"
+        expected_key = {test_key_name: self.serializer.serialize(test_key_value)}
+
+        # Act
+        self.gw.delete_item(
+            table_name=self.TEST_TABLE_NAME,
+            key_name=test_key_name,
+            key_value=test_key_value,
+        )
+
+        # Assert
+        self.gw.client.delete_item.assert_called_with(
+            TableName=self.TEST_TABLE_NAME, Key=expected_key
+        )
+
+    def test_update(self):
+        # Arrange
+        test_key_name = "instance_id"
+        test_key_value = "111"
+        test_attribute_name = "instance_name"
+        test_new_attribute_value = "test_update"
+        test_boto3_key = {test_key_name: self.serializer.serialize(test_key_value)}
+        test_update_expression = f"SET {test_attribute_name} = :new_data"
+        test_boto3_attributes = {
+            ":new_data": self.serializer.serialize(test_new_attribute_value)
+        }
+        # Act
+        self.gw.update_item(
+            table_name=self.TEST_TABLE_NAME,
+            key_name=test_key_name,
+            key_value=test_key_value,
+            attribute_name=test_attribute_name,
+            new_value=test_new_attribute_value,
+        )
+
+        # Assert
+        self.gw.client.update_item.assert_called_with(
+            TableName=self.TEST_TABLE_NAME,
+            Key=test_boto3_key,
+            UpdateExpression=test_update_expression,
+            ExpressionAttributeValues=test_boto3_attributes,
+            ConditionExpression="attribute_exists(instance_id)",
+        )

--- a/onedocker/tests/mapper/test_aws.py
+++ b/onedocker/tests/mapper/test_aws.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from onedocker.entity.measurement import MeasurementType
+from onedocker.entity.metadata import PackageMetadata
+from onedocker.mapper.aws import map_dynamodbitem_to_packagemetadata
+
+
+class TestAWSMapper(unittest.TestCase):
+    def test_map_dynamodbitem_to_packagemetadata(self):
+        # Arrange
+        test_package_name = "PA"
+        test_package_version = "0.0.1"
+        test_md5_measurement = "123"
+        test_dynamodb_item = {
+            "package_name": test_package_name,
+            "version": test_package_version,
+            "measurements": {"MD5": test_md5_measurement},
+        }
+        expect_res = PackageMetadata(
+            package_name=test_package_name,
+            version=test_package_version,
+            measurements={MeasurementType.MD5: test_md5_measurement},
+        )
+
+        # Act
+        res = map_dynamodbitem_to_packagemetadata(dynamodb_item=test_dynamodb_item)
+
+        # Assert
+        self.assertEqual(expect_res, res)

--- a/onedocker/tests/service/test_metadata.py
+++ b/onedocker/tests/service/test_metadata.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from onedocker.entity.measurement import Measurement, MeasurementType
+from onedocker.entity.metadata import PackageMetadata
+from onedocker.service.metadata import MetadataService
+
+TEST_METADATA_TABLE = "metadata_test"
+TEST_METADATA_KEY = "primary_key"
+TEST_REGION = "us-west-1"
+TEST_KEY_ID = "test-key-id"
+TEST_KEY_DATA = "test-key-data"
+TEST_PACKAGE_NAME = "PL"
+TEST_PACKAGE_VERSION = "1.1"
+TEST_MEASUREMENT_KEY1 = "MD5"
+TEST_MEASUREMENT_KEY2 = "SHA256"
+TEST_MEASUREMENT1 = Measurement(
+    MeasurementType(TEST_MEASUREMENT_KEY1), value="md5-hash"
+)
+TEST_MEASUREMENT2 = Measurement(
+    MeasurementType(TEST_MEASUREMENT_KEY2), value="sha256-hash"
+)
+
+
+class TestMetadataService(unittest.TestCase):
+    @patch("onedocker.gateway.dynamodb.DynamoDBGateway")
+    def setUp(self, MockDynamoDBGateway):
+        self.md_svc = MetadataService(
+            region=TEST_REGION,
+            table_name=TEST_METADATA_TABLE,
+            key_name=TEST_METADATA_KEY,
+            access_key_id=TEST_KEY_ID,
+            access_key_data=TEST_KEY_DATA,
+        )
+        self.md_svc.dynamodb_gateway = MockDynamoDBGateway()
+
+    def test_get_medadata(self):
+        # Arrange
+        expected_attributes = {
+            "package_name": TEST_PACKAGE_NAME,
+            "version": TEST_PACKAGE_VERSION,
+            "measurements": {
+                TEST_MEASUREMENT_KEY1: TEST_MEASUREMENT1,
+                TEST_MEASUREMENT_KEY2: TEST_MEASUREMENT2,
+            },
+        }
+        expect_res = PackageMetadata(
+            package_name=TEST_PACKAGE_NAME,
+            version=TEST_PACKAGE_VERSION,
+            measurements={
+                MeasurementType(TEST_MEASUREMENT_KEY1): TEST_MEASUREMENT1,
+                MeasurementType(TEST_MEASUREMENT_KEY2): TEST_MEASUREMENT2,
+            },
+        )
+        self.md_svc.dynamodb_gateway.get_item = MagicMock(
+            return_value=expected_attributes
+        )
+
+        # Act
+        res = self.md_svc.get_medadata(
+            package_name=TEST_PACKAGE_NAME, version=TEST_PACKAGE_VERSION
+        )
+
+        # Assert
+        self.assertEqual(expect_res, res)
+        self.md_svc.dynamodb_gateway.get_item.assert_called()
+
+    def test_put_medadata(self):
+        # Arrange
+        md_dict = {
+            self.md_svc.key_name: self.md_svc._build_key(
+                TEST_PACKAGE_NAME, TEST_PACKAGE_VERSION
+            ),
+            "package_name": TEST_PACKAGE_NAME,
+            "version": TEST_PACKAGE_VERSION,
+            "measurements": {
+                TEST_MEASUREMENT_KEY1: TEST_MEASUREMENT1,
+                TEST_MEASUREMENT_KEY2: TEST_MEASUREMENT2,
+            },
+        }
+        md = PackageMetadata(
+            package_name=TEST_PACKAGE_NAME,
+            version=TEST_PACKAGE_VERSION,
+            measurements={
+                MeasurementType(TEST_MEASUREMENT_KEY1): TEST_MEASUREMENT1,
+                MeasurementType(TEST_MEASUREMENT_KEY2): TEST_MEASUREMENT2,
+            },
+        )
+        self.md_svc.dynamodb_gateway.put_item = MagicMock()
+
+        # Act
+        self.md_svc.put_metadata(metadata=md)
+
+        # Assert
+        self.md_svc.dynamodb_gateway.put_item.assert_called_with(
+            table_name=self.md_svc.table_name, item=md_dict
+        )


### PR DESCRIPTION
Summary:
As implementation and integration tests are done, this diff is to move metadata service to OSS folder. This won't be release until H1 2023. But we need to move this to OSS in order to integrate this feature to OneDocker repository service.

I'm in the process of requesting exception for this change. Will land only when diff and exception are both approved

Differential Revision: D41481063

