### PR TITLE
Minor fixes to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to FBPCS
+# Contributing to FBPCP
 We want to make contributing to this project as easy and transparent as
 possible.
 

--- a/docs/FBPCPComponents.md
+++ b/docs/FBPCPComponents.md
@@ -1,5 +1,5 @@
 ### Components:
-Facebook Private Computation Service follows [MVCS(Model View Controller Service)](MVCS.md) design pattern.
+Facebook Private Computation Platform follows [MVCS(Model View Controller Service)](MVCS.md) design pattern.
 
 ### Repository
 Repository is responsible for encapsulating database-like operations. In our design, we have MPC instance repositories for both Amazon S3 and local storage. The end point service will call MPC service to create an MPC instance and all the files and information related to this instance will be stored on Amazon S3 or local storage, depending on which repository the end point service is using.


### PR DESCRIPTION
Summary:
Part 1 of 3:

This diff fixes some copy paste issues in the existing PCP documentation. It does not remove the name "Facebook" from the project name. (Pending future decision)

Differential Revision: D41597612

