### PR TITLE
Change container layer interface to accept list of env_vars

### DIFF
--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import abc
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from fbpcp.entity.cluster_instance import Cluster
 
@@ -44,7 +44,7 @@ class ContainerService(abc.ABC):
         self,
         container_definition: str,
         cmds: List[str],
-        env_vars: Optional[Dict[str, str]] = None,
+        env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         container_type: Optional[ContainerType] = None,
     ) -> List[ContainerInstance]:
         pass

--- a/fbpcp/service/container_aws.py
+++ b/fbpcp/service/container_aws.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from fbpcp.entity.cloud_provider import CloudProvider
 
@@ -88,9 +88,12 @@ class AWSContainerService(ContainerService):
         self,
         container_definition: str,
         cmds: List[str],
-        env_vars: Optional[Dict[str, str]] = None,
+        env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         container_type: Optional[ContainerType] = None,
     ) -> List[ContainerInstance]:
+        # TODO: When given a list of env_vars, pass each env_var_dict to one instance
+        if type(env_vars) is list:
+            env_vars = env_vars[0] if env_vars else None
         instances = [
             self.create_instance(
                 container_definition=container_definition,


### PR DESCRIPTION
Summary:
One of the requirements of TLS/OPA integration is to be able to send a set of env_vars for each container. Currently, the infra only supports a single set of env_vars for all containers. This stack of diffs is to enable this feature for private lift runs.

This diff:
* modify the container interface to accept a list of env_vars in addition to a single env_vars dict in `create_instances`
* this diff only changes the interface and the functionality remains the same.

Next:
* changes in onedocker layer
* changes in pcs layer (note that this would have fbpcp release dependency)

Reviewed By: liliarizona

Differential Revision: D42199006

