### PR TITLE
Fix a bug that causes a failure if the directory is empty

### DIFF
--- a/fbpcp/gateway/s3.py
+++ b/fbpcp/gateway/s3.py
@@ -102,11 +102,20 @@ class S3Gateway(AWSGateway):
 
     @error_handler
     def list_folders(self, bucket: str, key: str) -> List[str]:
+        """List the folders for a given S3 path (key)
+
+        Args:
+            bucket: The name of the S3 bucket
+            key: The path in the bucket that we want to list the folders of
+
+        Returns:
+            return: A list of the folders in the base path (key)
+        """
         key = key + "/"
         response = self.client.list_objects_v2(Bucket=bucket, Prefix=key, Delimiter="/")
         return [
             prefix_dict["Prefix"][len(key) : -1]
-            for prefix_dict in response.get("CommonPrefixes")
+            for prefix_dict in response.get("CommonPrefixes", [])
         ]
 
     @error_handler


### PR DESCRIPTION
Summary:
## Context
I was testing the required changes for uploading the binaries using the onedocker-cli and ran into an issue where running the upload command on an empty folder in a bucket would cause the following error:
```
(venv)  ✘ brianmuse@brianmuse-mbp  ~/repos/forks/fbpcs   main ±  ./upload-binaries-to-s3-test.sh emp_games brian_test
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:onedocker.script.cli.onedocker_cli: Starting uploading package private_lift/lift at 'binaries_out/lift_calculator', version brian_test...
INFO:onedocker.script.cli.onedocker_cli:Uploading binary for package private_lift/lift: brian_test
ERROR:fbpcp.decorator.error_handler:'NoneType' object is not iterable
Traceback (most recent call last):
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/fbpcp/decorator/error_handler.py", line 26, in wrapper
    return f(*args, **kwargs)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/fbpcp/gateway/s3.py", line 107, in list_folders
    return [
TypeError: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/opt/facebook/nix/store/p4yr7ykc4mzzbsh489w9bysqcr0l0r8a-python3-3.8.9/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/facebook/nix/store/p4yr7ykc4mzzbsh489w9bysqcr0l0r8a-python3-3.8.9/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/onedocker/script/cli/__main__.py", line 11, in <module>
    main()
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/onedocker/script/cli/onedocker_cli.py", line 238, in main
    _upload(package_path, package_name, version)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/onedocker/script/cli/onedocker_cli.py", line 63, in _upload
    onedocker_repo_svc.upload(package_name, version, package_path)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/onedocker/repository/onedocker_repository_service.py", line 35, in upload
    all_versions = self.package_repo.get_package_versions(package_name)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/onedocker/repository/onedocker_package.py", line 38, in get_package_versions
    return self.storage_svc.list_folders(package_parent_path)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/fbpcp/service/storage_s3.py", line 222, in list_folders
    return self.s3_gateway.list_folders(s3_path.bucket, s3_path.key)
  File "/Users/brianmuse/repos/forks/fbpcs/venv/lib/python3.8/site-packages/fbpcp/decorator/error_handler.py", line 39, in wrapper
    raise PcpError(err) from None
fbpcp.error.pcp.PcpError: 'NoneType' object is not iterable
```

I found out this was an issue with the list_folders function and it was doing a dictionary `get` without a proper default in the case it was missing. This diff corrects that.

Differential Revision: D42350514

