### PR TITLE
Change onedocker service interface to allow passing env_vars list

### DIFF
--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -8,7 +8,7 @@
 
 import asyncio
 import logging
-from typing import Dict, Final, List, Optional
+from typing import Dict, Final, List, Optional, Union
 
 from fbpcp.decorator.metrics import duration_time, error_counter, request_counter
 from fbpcp.entity.certificate_request import CertificateRequest
@@ -81,7 +81,7 @@ class OneDockerService(MetricsGetter):
         task_definition: Optional[str] = None,
         version: str = DEFAULT_BINARY_VERSION,
         cmd_args: str = "",
-        env_vars: Optional[Dict[str, str]] = None,
+        env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         timeout: Optional[int] = None,
         tag: Optional[str] = None,
         certificate_request: Optional[CertificateRequest] = None,
@@ -96,7 +96,9 @@ class OneDockerService(MetricsGetter):
                                 when starting this container
             version:            The version of the MPC binary to run. This parameter defaults to the 'latest' binary version.
             cmd_args:           A string that is used to override the command in docker containers
-            env_vars:           environment variable overrides in docker containers
+            env_vars:           Environment variable overrides in docker containers. When given a single dictionary,
+                                it will be applied to all container. When given a list of dictionraies, each will be assigned
+                                to one container.
             timeout:            container timeout. If specified, docker container would be forced to stop
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
@@ -123,7 +125,7 @@ class OneDockerService(MetricsGetter):
         task_definition: Optional[str] = None,
         version: str = DEFAULT_BINARY_VERSION,
         cmd_args_list: Optional[List[str]] = None,
-        env_vars: Optional[Dict[str, str]] = None,
+        env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         timeout: Optional[int] = None,
         tag: Optional[str] = None,
         certificate_request: Optional[CertificateRequest] = None,
@@ -137,7 +139,9 @@ class OneDockerService(MetricsGetter):
                                 when starting this container
             version:            The version of the MPC binary to run. This parameter defaults to the 'latest' binary version.
             cmd_args_list:      A list of command overrides in docker containers
-            env_vars:           environment variable overrides in docker containers
+            env_vars:           Environment variable overrides in docker containers. When given a single dictionary,
+                                it will be applied to all container. When given a list of dictionraies, each will be assigned
+                                to one container.
             timeout:            container timeout. If specified, docker container would be forced to stop
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
@@ -147,6 +151,11 @@ class OneDockerService(MetricsGetter):
         """
         if not cmd_args_list:
             raise ValueError("Command Argument List shouldn't be None or Empty")
+
+        if type(env_vars) is list and len(env_vars) != len(cmd_args_list):
+            raise ValueError(
+                f"Length of env_vars {len(env_vars)} not equal to the length of cmd_args_list {len(cmd_args_list)}."
+            )
 
         cmds = [
             self._get_cmd(package_name, version, cmd_args, timeout, certificate_request)

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -33,7 +33,6 @@ TEST_CONTAINER_DEFNITION = "test-container-definition"
 
 TEST_ENV_VARS = {"k1": "v1", "k2": "v2"}
 TEST_ENV_VARS_2 = {"k3": "v3", "k4": "v4"}
-TEST_LIST_OF_ENV_VARS = [TEST_ENV_VARS, TEST_ENV_VARS_2]
 TEST_CMD_1 = "test_1"
 TEST_CMD_2 = "test_2"
 TEST_CONTAINER_TYPE = ContainerType.MEDIUM
@@ -158,7 +157,7 @@ class TestAWSContainerService(unittest.TestCase):
                 cmd=TEST_CMD_2,
                 cluster=TEST_CLUSTER,
                 subnets=TEST_SUBNETS,
-                env_vars=TEST_ENV_VARS,
+                env_vars=TEST_ENV_VARS_2,
                 cpu=self.test_container_config.cpu,
                 memory=self.test_container_config.memory,
             ),
@@ -170,7 +169,7 @@ class TestAWSContainerService(unittest.TestCase):
         ] = self.container_svc.create_instances(
             container_definition=f"{TEST_TASK_DEFNITION}#{TEST_CONTAINER_DEFNITION}",
             cmds=cmd_list,
-            env_vars=TEST_LIST_OF_ENV_VARS,
+            env_vars=[TEST_ENV_VARS, TEST_ENV_VARS_2],
             container_type=TEST_CONTAINER_TYPE,
         )
 
@@ -182,6 +181,27 @@ class TestAWSContainerService(unittest.TestCase):
         self.assertEqual(
             self.container_svc.ecs_gateway.run_task.call_count, len(created_instances)
         )
+
+    def test_create_instances_throw_with_invalid_list_of_env_vars(self):
+        # Arrange
+        cmd_list = [TEST_CMD_1, TEST_CMD_2, TEST_CMD_2]
+
+        # Act & Assert
+        with self.assertRaises(ValueError):
+            self.container_svc.create_instances(
+                container_definition=f"{TEST_TASK_DEFNITION}#{TEST_CONTAINER_DEFNITION}",
+                cmds=cmd_list,
+                env_vars=[TEST_ENV_VARS],
+                container_type=TEST_CONTAINER_TYPE,
+            )
+
+        with self.assertRaises(ValueError):
+            self.container_svc.create_instances(
+                container_definition=f"{TEST_TASK_DEFNITION}#{TEST_CONTAINER_DEFNITION}",
+                cmds=cmd_list,
+                env_vars=[],
+                container_type=TEST_CONTAINER_TYPE,
+            )
 
     def test_create_instance(self):
         # Arrange


### PR DESCRIPTION
Summary:
As title. Please see more context in D42199006 (https://github.com/facebookresearch/fbpcp/commit/750b5ce3e59534471472dcf5ca3664ca38a0fc34)

We have changed the container layer interface in prev diffs in the stack and the goal is to pass down env_vars as list from PCS, thus we need this change in onedocker layer as well.

Reviewed By: jliu0501

Differential Revision: D42211965

