### PR TITLE
Release fbpcp 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.4.0] - 2023-01-17
+### Added
+- OneDocker Repository Service
+- OneDocker Measurement Service
+- OneDocker Metadata Service
+### Changed
+- Add support for passing list of environment variables in OneDocker and Container Service
+
 ## [0.3.4] - 2022-09-30
 ### Changed
 - MPCService container start-up only retry failed containers

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.3.4",
+    version="0.4.0",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
Followed the release guideline [here](https://www.internalfb.com/intern/wiki/Private_Computation_Infra/Cloud_Infra/Private_Computation_Platform_(PCP)/FBPCP_Release_Process/)

Bumped to 0.4.1 because this change is an added functionality and qualifies for a minor increment and we already have a 0.4.0 in changelog.

Differential Revision: D42560195

