### PR TITLE
Remove invalid S3 bucket from unit tests - OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 - Delete deprecated MPC entities in FBPCP (moved to FBPCS)
+- Replace invalid S3 bucket from OneDocker unit tests with mock path
 
 ## [0.4.0] - 2023-01-17
 ### Added

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -6,7 +6,7 @@
 
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from docopt import docopt
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
@@ -132,11 +132,16 @@ class TestOnedockerRunner(unittest.TestCase):
             self.assertEqual(cm.exception.code, 1)
 
     @patch.object(OneDockerRepositoryService, "download")
+    @patch("onedocker.script.runner.onedocker_runner.S3Path")
+    @patch("onedocker.script.runner.onedocker_runner.S3StorageService")
     def test_main(
         self,
+        mockS3StorageService,
+        mockS3Path,
         mockOneDockerRepositoryServiceDownload,
     ):
         # Arrange
+        mockS3Path.region = MagicMock(return_value="us_west_1")
         with patch.object(
             sys,
             "argv",
@@ -144,7 +149,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 "onedocker-runner",
                 "echo",
                 "--version=latest",
-                "--repository_path=https://onedocker-runner-unittest-asacheti.s3.us-west-2.amazonaws.com/",
+                "--repository_path=test_repo_path",
                 "--timeout=1200",
                 "--exe_path=/usr/bin/",
                 "--exe_args=test_message",
@@ -214,6 +219,6 @@ class TestOnedockerRunner(unittest.TestCase):
 
 def getenv(key):
     if key == "ONEDOCKER_REPOSITORY_PATH":
-        return "https://onedocker-package-repo.s3.us-west-2.amazonaws.com/"
+        return "test_repo_path"
     else:
         raise KeyError from None


### PR DESCRIPTION
Summary:
The S3 buckets used from onedocker runner unit test are out dated and has been taken over externally. Although these S3 buckets are not actually accessed in the unitest as the connection are mocked. These usage still raise whitehat security task. To resolve this issue and avoid triggering similar tasks in the future, this diff is to replace the invalid buckets with mock S3 path.

This diff is to change the OSS unittest with changelog change.

1. Type of changes
-modify

2. Requires an OSS plan：
-no

3. OSS plan link or explain why the change doesn't require an OSS plan:
-minor change to unittest

4. Have you added change description to [CHANGELOG.md](https://www.internalfb.com/code/fbsource/fbcode/measurement/private_measurement/pcp/oss/CHANGELOG.md)? Please provide diff # if not in this diff.
-yes

5. Is it covered by unit test, please provide a link/diff if test is not included in this diff
-yes

6. Is it covered by integration test, please provide a link/diff if test is not included in this diff
-no

Differential Revision: D43511094

