### PR TITLE
Create exit_code entry in ContainerInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add an optional exit_code entry in ContainerInstance
 ### Changed
 ### Removed
 - Delete deprecated MPC entities in FBPCP (moved to FBPCS)

--- a/fbpcp/entity/container_instance.py
+++ b/fbpcp/entity/container_instance.py
@@ -28,3 +28,4 @@ class ContainerInstance:
     status: ContainerInstanceStatus = ContainerInstanceStatus.UNKNOWN
     cpu: Optional[int] = None  # Number of vCPU
     memory: Optional[int] = None  # Memory in GB
+    exit_code: Optional[int] = None

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -78,6 +78,7 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
         status=status,
         cpu=vcpu,
         memory=memory_in_gb,
+        exit_code=container.get("exitCode"),
     )
 
 

--- a/tests/mapper/test_aws.py
+++ b/tests/mapper/test_aws.py
@@ -95,22 +95,29 @@ class TestAWSMapper(unittest.TestCase):
         }
         expected_task_list = [
             ContainerInstance(
-                self.TEST_TASK_ARN,
-                self.TEST_IP_ADDRESS,
-                ContainerInstanceStatus.STARTED,
+                instance_id=self.TEST_TASK_ARN,
+                ip_address=self.TEST_IP_ADDRESS,
+                status=ContainerInstanceStatus.STARTED,
             ),
             ContainerInstance(
-                self.TEST_TASK_ARN,
-                None,
-                ContainerInstanceStatus.COMPLETED,
+                instance_id=self.TEST_TASK_ARN,
+                ip_address=None,
+                status=ContainerInstanceStatus.COMPLETED,
                 cpu=self.TEST_CPU,
                 memory=self.TEST_MEMORY,
+                exit_code=0,
             ),
-            ContainerInstance(self.TEST_TASK_ARN, None, ContainerInstanceStatus.FAILED),
             ContainerInstance(
-                self.TEST_TASK_ARN,
-                None,
-                ContainerInstanceStatus.UNKNOWN,
+                instance_id=self.TEST_TASK_ARN,
+                ip_address=None,
+                status=ContainerInstanceStatus.FAILED,
+                exit_code=1,
+            ),
+            ContainerInstance(
+                instance_id=self.TEST_TASK_ARN,
+                ip_address=None,
+                status=ContainerInstanceStatus.UNKNOWN,
+                exit_code=-1,
             ),
         ]
         # Act


### PR DESCRIPTION
Summary:
To allow OneDocker Insights to monitor the exit codes of containers, we propose to add exit_code in ContainerInstance in this [design](https://docs.google.com/document/d/1J58imAR4xGuMzj_nGyssHhdg4-6COc7OwOEaJo-FkKU/edit#)
## OSS Checklist
1. Type of changes:
New feature
2. Requires an OSS plan:
No
3. OSS plan link or explain why the change doesn't require an OSS plan:
This adds an optional exit_code entry in ContainerInstance, which is a monitor change and backward compatible;
4. Have you added change description to [CHANGELOG.md](https://www.internalfb.com/code/fbsource/fbcode/measurement/private_measurement/pcp/oss/CHANGELOG.md)? Please provide diff # if not in this diff:
Yes
5. Is it covered by unit test, please provide a link/diff if test is not included in this diff:
yes
6. Is it covered by integration test, please provide a link/diff if test is not included in this diff:
yes

Differential Revision: D43414345

