### PR TITLE
Create Enum for exit codes in OneDocker Runner

### DIFF
--- a/onedocker/entity/exit_code.py
+++ b/onedocker/entity/exit_code.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    """Custom exit codes for OneDocker containers.
+
+    Unix uses error codes above 125 specially for failures, so they should be avoided for program errors.
+
+    The meaning of the codes is approximately as follows:
+        SUCCESS -- The program succeeded.
+        EXE_ERROR -- The executable itself exited with non-zero code.
+        ERROR -- Catchall for general errors.
+        SERVICE_UNAVAILABLE -- A service is unavailable. This can occur if a support program or file is unavailable.
+        TIMEOUT -- The program timed out.
+        SIGINT -- The program received SIGINT signal.
+
+    For other exit codes please refer to https://man.freebsd.org/cgi/man.cgi?sysexits.
+    """
+
+    SUCCESS = 0
+    EXE_ERROR = 1
+    ERROR = 64
+    SERVICE_UNAVAILABLE = 69
+    TIMEOUT = 124
+    SIGINT = 130


### PR DESCRIPTION
Summary:
This diff is to create an enum of exit codes that will be used by OneDocker Runner for different exceptions. This follows Table 1 in the [Granular Exit Code Design](https://docs.google.com/document/d/1J58imAR4xGuMzj_nGyssHhdg4-6COc7OwOEaJo-FkKU/edit#bookmark=id.a32afzr0f61x):
https://pxl.cl/2tXrd

OSS Checklist will be combined with later runner diff.

Differential Revision: D43586670

