### PR TITLE
Refractor OneDocker Runner to use granular exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an optional exit_code entry in ContainerInstance
 - Add OPAWDL
 ### Changed
+- Refactor OneDocker Runner to use granular exit codes
 ### Removed
 - Delete deprecated MPC entities in FBPCP (moved to FBPCS)
 - Replace invalid S3 bucket from OneDocker unit tests with mock path

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 from docopt import docopt
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
 from fbpcp.error.pcp import InvalidParameterError
+from onedocker.entity.exit_code import ExitCode
 from onedocker.repository.onedocker_repository_service import OneDockerRepositoryService
 from onedocker.script.runner.onedocker_runner import (
     __doc__ as __onedocker_runner_doc__,
@@ -108,7 +109,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 main()
 
             # Assert
-            self.assertEqual(cm.exception.code, 0)
+            self.assertEqual(cm.exception.code, ExitCode.SUCCESS)
 
     def test_main_local_timeout(self):
         # Arrange
@@ -117,10 +118,11 @@ class TestOnedockerRunner(unittest.TestCase):
             "argv",
             [
                 "onedocker-runner",
-                "nano",
+                "sleep",
                 "--version=latest",
                 "--repository_path=local",
-                "--exe_path=test.py",
+                "--exe_path=/usr/bin/",
+                "--exe_args=2",
                 "--timeout=1",
             ],
         ):
@@ -129,7 +131,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 main()
 
             # Assert
-            self.assertEqual(cm.exception.code, 1)
+            self.assertEqual(cm.exception.code, ExitCode.TIMEOUT)
 
     @patch.object(OneDockerRepositoryService, "download")
     @patch("onedocker.script.runner.onedocker_runner.S3Path")
@@ -160,7 +162,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 main()
 
             # Assert
-            self.assertEqual(cm.exception.code, 0)
+            self.assertEqual(cm.exception.code, ExitCode.SUCCESS)
             mockOneDockerRepositoryServiceDownload.assert_called_once_with(
                 "echo",
                 "latest",
@@ -214,7 +216,7 @@ class TestOnedockerRunner(unittest.TestCase):
                 with self.assertRaises(SystemExit) as cm:
                     main()
                 # Assert
-                self.assertEqual(cm.exception.code, 0)
+                self.assertEqual(cm.exception.code, ExitCode.SUCCESS)
 
 
 def getenv(key):


### PR DESCRIPTION
Summary:
## This Commit
- This is to refractor OneDocker Runner to use different exit codes for different exceptions. Enum of exit codes is in D43586670.
- Fixed the flaky test ```test_main_local_timeout()```
## OSS Checklist
1. Type of changes:
Change
2. Requires an OSS plan:
No
3. OSS plan link or explain why the change doesn't require an OSS plan:
This only changes exit codes and does not touch any business logic.
4. Have you added change description to [CHANGELOG.md](https://www.internalfb.com/code/fbsource/fbcode/measurement/private_measurement/pcp/oss/CHANGELOG.md)? Please provide diff # if not in this diff:
Yes
5. Is it covered by unit test, please provide a link/diff if test is not included in this diff:
yes, D43592235
6. Is it covered by integration test, please provide a link/diff if test is not included in this diff:
yes

Differential Revision: D43592192

