### PR TITLE
remove unused default version of the binary

### DIFF
--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -54,9 +54,6 @@ DEFAULT_REPOSITORY_PATH = (
 # The default path in the Docker image that is going to host the executables
 DEFAULT_EXE_FOLDER = "/root/onedocker/package/"
 
-# the default version of the binary
-DEFAULT_BINARY_VERSION = "latest"
-
 logger: logging.Logger
 
 


### PR DESCRIPTION
Summary: This default value was defined previously when version is optional and does not have any useage after the version is enforced to onedocker runner.

Reviewed By: zhuang-93

Differential Revision: D43925603

