### PR TITLE
Fix the key error when getting ip address from AWS response body

### DIFF
--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import logging
 from decimal import Decimal
 from typing import Any, Dict, List
 
@@ -54,8 +55,9 @@ def map_mb_to_gb(mb: str) -> int:
 
 def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
     container = task["containers"][0]
+    logging.debug(f"The ECS task response from AWS: {task}")
     ip_v4 = (
-        container["networkInterfaces"][0]["privateIpv4Address"]
+        container["networkInterfaces"][0].get("privateIpv4Address")
         if len(container["networkInterfaces"]) > 0
         else None
     )


### PR DESCRIPTION
Summary:
As title, release is blocked by an KeyError in getting ip address from AWS response, because we directly reading the key/value from dictionary.

#internal
See more in T147622401

Reviewed By: jliu0501

Differential Revision: D43958838

