### PR TITLE
Integrate OPAWDL with OneDocker Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2023-3-09
 ### Added
 - Add an optional exit_code entry in ContainerInstance
-- Add OPAWDL
+- Add OneDocker Plugin Architecture
 ### Changed
 - Refactor OneDocker Runner to use granular exit codes
 - Fixed key error when getting ip address from AWS response

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -85,6 +85,7 @@ class OneDockerService(MetricsGetter):
         timeout: Optional[int] = None,
         tag: Optional[str] = None,
         certificate_request: Optional[CertificateRequest] = None,
+        opa_workflow_path: Optional[str] = None,
         container_type: Optional[ContainerType] = None,
     ) -> ContainerInstance:
         """
@@ -102,6 +103,7 @@ class OneDockerService(MetricsGetter):
             timeout:            container timeout. If specified, docker container would be forced to stop
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
+            opa_workflow_path:  A string that denotes the path to a specified opa workflow. Supported Path type: local.
 
         """
         return self.start_containers(
@@ -113,6 +115,7 @@ class OneDockerService(MetricsGetter):
             timeout=timeout,
             tag=tag,
             certificate_request=certificate_request,
+            opa_workflow_path=opa_workflow_path,
             container_type=container_type,
         )[0]
 
@@ -129,6 +132,7 @@ class OneDockerService(MetricsGetter):
         timeout: Optional[int] = None,
         tag: Optional[str] = None,
         certificate_request: Optional[CertificateRequest] = None,
+        opa_workflow_path: Optional[str] = None,
         container_type: Optional[ContainerType] = None,
     ) -> List[ContainerInstance]:
         """Spin up cloud containers according to command arg list.
@@ -145,6 +149,7 @@ class OneDockerService(MetricsGetter):
             timeout:            container timeout. If specified, docker container would be forced to stop
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
+            opa_workflow_path:  A string that denotes the path to a specified opa workflow. Supported Path type: local.
 
         Returns:
             A list of the containers that were successfuly started
@@ -158,7 +163,14 @@ class OneDockerService(MetricsGetter):
             )
 
         cmds = [
-            self._get_cmd(package_name, version, cmd_args, timeout, certificate_request)
+            self._get_cmd(
+                package_name,
+                version,
+                cmd_args,
+                timeout,
+                certificate_request,
+                opa_workflow_path,
+            )
             for cmd_args in cmd_args_list
         ]
         container_type_log = f" of {container_type} type" if container_type else ""
@@ -264,10 +276,13 @@ class OneDockerService(MetricsGetter):
         cmd_args: Optional[str] = None,
         timeout: Optional[int] = None,
         certificate_request: Optional[CertificateRequest] = None,
+        opa_workflow_path: Optional[str] = None,
     ) -> str:
         args_dict = {"exe_args": cmd_args, "version": version, "timeout": timeout}
         if certificate_request:
             args_dict["cert_params"] = certificate_request.convert_to_cert_params()
+        if opa_workflow_path:
+            args_dict["opa_workflow_path"] = opa_workflow_path
         runner_args = build_cmd_args(**args_dict)
         return ONEDOCKER_CMD_PREFIX.format(
             package_name=package_name,

--- a/onedocker/tests/script/runner/test_onedocker_runner.py
+++ b/onedocker/tests/script/runner/test_onedocker_runner.py
@@ -285,6 +285,41 @@ class TestOnedockerRunner(unittest.TestCase):
                 # Assert
                 self.assertEqual(cm.exception.code, ExitCode.SUCCESS)
 
+    @patch.object(OneDockerRepositoryService, "download")
+    @patch("onedocker.script.runner.onedocker_runner.S3Path")
+    @patch("onedocker.script.runner.onedocker_runner.S3StorageService")
+    @patch("onedocker.script.runner.onedocker_runner._run_opawdl")
+    def test_main_with_opa_enabled(
+        self,
+        mockOneDockerRunOPAWDL,
+        MockS3StorageService,
+        MockS3Path,
+        mockOneDockerRepositoryServiceDownload,
+    ):
+        # Arrange
+        test_opa_workflow_path = "/home/xyz.json"
+        MockS3Path.region = MagicMock(return_value="us_west_1")
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "onedocker-runner",
+                "echo",
+                "--version=latest",
+                "--repository_path=test_repo_path",
+                "--timeout=1200",
+                "--exe_path=/usr/bin/",
+                "--exe_args=test_message",
+                f"--opa_workflow_path={test_opa_workflow_path}",
+            ],
+        ):
+            # Act
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            # Assert
+            self.assertEqual(cm.exception.code, 0)
+            mockOneDockerRunOPAWDL.assert_called_once_with(test_opa_workflow_path)
+
 
 def getenv(key):
     if key == "ONEDOCKER_REPOSITORY_PATH":

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -18,6 +18,7 @@ from fbpcp.error.pcp import PcpError
 from fbpcp.service.onedocker import (
     METRICS_START_CONTAINERS_COUNT,
     METRICS_START_CONTAINERS_DURATION,
+    ONEDOCKER_CMD_PREFIX,
     OneDockerService,
 )
 
@@ -44,6 +45,7 @@ TEST_CONTAINER_TYPE: ContainerType = ContainerType.LARGE
 TEST_CONTAINER_CONFIG: ContainerTypeConfig = ContainerTypeConfig.get_config(
     TEST_CLOUD_PROVIDER, TEST_CONTAINER_TYPE
 )
+TEST_OPA_WORKFLOW_PATH = "/folder/file.json"
 
 
 class TestOneDockerServiceSync(unittest.TestCase):
@@ -69,6 +71,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             cmd_args=TEST_CMD_ARGS_LIST[0],
             certificate_request=None,
             container_type=TEST_CONTAINER_TYPE,
+            opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
         )
         # Assert
         self.assertEqual(returned_container_info, mocked_container_info)
@@ -102,6 +105,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 TEST_CMD_ARGS_LIST[0],
                 TEST_TIMEOUT,
                 test_cert_request,
+                TEST_OPA_WORKFLOW_PATH,
             ),
             call(
                 TEST_PACKAGE_NAME,
@@ -109,6 +113,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 TEST_CMD_ARGS_LIST[1],
                 TEST_TIMEOUT,
                 test_cert_request,
+                TEST_OPA_WORKFLOW_PATH,
             ),
         ]
         self.onedocker_svc._get_cmd = MagicMock()
@@ -125,6 +130,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             timeout=TEST_TIMEOUT,
             certificate_request=test_cert_request,
             container_type=TEST_CONTAINER_TYPE,
+            opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
         )
 
         # Assert
@@ -239,6 +245,26 @@ class TestOneDockerServiceSync(unittest.TestCase):
         # Assert
         self.assertEqual(result, expected_cmd)
 
+    def test_get_cmd_with_opa_workflow_path(self):
+        # Arrange
+        expected_runner_args = f"--exe_args={quote(str(TEST_CMD_ARGS_LIST[0]))} --version={quote(str(TEST_VERSION))} --timeout={quote(str(TEST_TIMEOUT))} --opa_workflow_path={TEST_OPA_WORKFLOW_PATH}"
+        expected_cmd = ONEDOCKER_CMD_PREFIX.format(
+            package_name=TEST_PACKAGE_NAME,
+            runner_args=expected_runner_args,
+        ).strip()
+
+        # Act
+        result = self.onedocker_svc._get_cmd(
+            package_name=TEST_PACKAGE_NAME,
+            version=TEST_VERSION,
+            cmd_args=TEST_CMD_ARGS_LIST[0],
+            timeout=TEST_TIMEOUT,
+            opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
+        )
+
+        # Assert
+        self.assertEqual(result, expected_cmd)
+
     def test_stop_containers(self):
         containers = [
             TEST_INSTANCE_ID_1,
@@ -263,6 +289,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 TEST_CMD_ARGS_LIST[0],
                 TEST_TIMEOUT,
                 TEST_CERTIFICATE_REQUEST,
+                TEST_OPA_WORKFLOW_PATH,
             ),
             call(
                 TEST_PACKAGE_NAME,
@@ -270,6 +297,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 TEST_CMD_ARGS_LIST[1],
                 TEST_TIMEOUT,
                 TEST_CERTIFICATE_REQUEST,
+                TEST_OPA_WORKFLOW_PATH,
             ),
         ]
         self.onedocker_svc._get_cmd = MagicMock()
@@ -280,6 +308,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             version=TEST_VERSION,
             timeout=TEST_TIMEOUT,
             certificate_request=TEST_CERTIFICATE_REQUEST,
+            opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
         )
         self.onedocker_svc._get_cmd.assert_has_calls(calls, any_order=False)
 


### PR DESCRIPTION
Summary:
This commit integrates OPAWDL with OneDocker Service via the following steps:
- Add argument `opa_workflow_path` to `start_container()` and `start_containers()`
- modify `_get_cmd()` accordingly so it builds the cmd with flag `opa_workflow_path` accordingly
- Add unittest case `test_get_cmd_with_opa_workflow_path()` and cover `opa_workflow_path` in related existing unittests.

Reviewed By: YigeZhu

Differential Revision: D43920563

