### PR TITLE
milestone 3 - Expand OneDocker CLI test API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 ### Removed
 
 ## [0.5.0] - 2023-3-21

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -45,6 +45,7 @@ class OneDockerService(MetricsGetter):
         container_svc: ContainerService,
         task_definition: Optional[str] = None,
         metrics: Optional[MetricsEmitter] = None,
+        container_cmd_prefix: Optional[str] = None,
     ) -> None:
         """Constructor of OneDockerService
         container_svc -- service to spawn container instances
@@ -56,6 +57,9 @@ class OneDockerService(MetricsGetter):
         self.container_svc = container_svc
         self.task_definition = task_definition
         self.metrics: Final[Optional[MetricsEmitter]] = metrics
+        self.container_cmd_prefix: str = (
+            container_cmd_prefix if container_cmd_prefix else ONEDOCKER_CMD_PREFIX
+        )
         self.logger: logging.Logger = logging.getLogger(__name__)
 
     def get_cluster(self) -> str:
@@ -284,7 +288,7 @@ class OneDockerService(MetricsGetter):
         if opa_workflow_path:
             args_dict["opa_workflow_path"] = opa_workflow_path
         runner_args = build_cmd_args(**args_dict)
-        return ONEDOCKER_CMD_PREFIX.format(
+        return self.container_cmd_prefix.format(
             package_name=package_name,
             runner_args=runner_args,
         ).strip()


### PR DESCRIPTION
Summary:
This is the milestone 3 for OneDocker E2E test framework.

This diff is to:
- Expand OneDocker CLI test API to support test with super OneDocker image
-  Expand OneDocker service to support testing scenario

next:
add specific test scenarios for this change.

Differential Revision: D44385739

