### PR TITLE
Add LimitedExceeded Error in PCP error(1/n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add Insights Service
+- Add LimitExceeded Exception as PcpError
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 ### Removed

--- a/fbpcp/error/mapper/aws.py
+++ b/fbpcp/error/mapper/aws.py
@@ -7,8 +7,12 @@
 # pyre-strict
 
 from botocore.exceptions import ClientError
-from fbpcp.error.pcp import InvalidParameterError, PcpError, ThrottlingError
-
+from fbpcp.error.pcp import (
+    InvalidParameterError,
+    LimitExceededError,
+    PcpError,
+    ThrottlingError,
+)
 
 # reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
 def map_aws_error(error: ClientError) -> PcpError:
@@ -21,5 +25,8 @@ def map_aws_error(error: ClientError) -> PcpError:
 
     if code == "ThrottlingException":
         return ThrottlingError(message)
+
+    if code == "LimitExceededException":
+        return LimitExceededError(message)
 
     return PcpError(message)

--- a/fbpcp/error/pcp.py
+++ b/fbpcp/error/pcp.py
@@ -17,3 +17,7 @@ class InvalidParameterError(PcpError):
 
 class ThrottlingError(PcpError):
     pass
+
+
+class LimitExceededError(PcpError):
+    pass

--- a/tests/decorator/test_error_handler.py
+++ b/tests/decorator/test_error_handler.py
@@ -8,7 +8,7 @@ import unittest
 
 from botocore.exceptions import ClientError
 from fbpcp.decorator.error_handler import error_handler
-from fbpcp.error.pcp import PcpError, ThrottlingError
+from fbpcp.error.pcp import LimitExceededError, PcpError, ThrottlingError
 from google.cloud.exceptions import TooManyRequests
 
 
@@ -67,3 +67,24 @@ class TestErrorHandler(unittest.TestCase):
             raise err
 
         self.assertRaises(ThrottlingError, foo)
+
+    def test_limit_exceeded_error(self):
+        @error_handler
+        def foo():
+            err = ClientError(
+                {
+                    "Error": {
+                        "Code": "LimitExceededException",
+                        "Message": "test",
+                    },
+                    "ResponseMetadata": {
+                        "RequestId": "test_id123",
+                        "HTTPStatusCode": 400,
+                    },
+                },
+                "test",
+            )
+
+            raise err
+
+        self.assertRaises(LimitExceededError, foo)


### PR DESCRIPTION
Summary:
Issue: Billing monitor encounters error "fbpcp.error.pcp.PcpError: An error occurred (LimitExceededException) when calling the GetCostAndUsage operation: Rate limit exceeded"

Mitigation: to mitigate the issue, I want to catch this exception in pcpError so I can handle it in next layer

Differential Revision: D44511906

