### PR TITLE
Update ECS gateway to run tasks with provided container overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
+- ECS Gateway Run Task support for overriding task role
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 ### Removed

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -21,6 +21,7 @@ class TestECSGateway(unittest.TestCase):
     TEST_TASK_ARN_2 = "test-task-arn-2"
     TEST_TASK_ARN_DNE = "test-task-arn-dne"
     TEST_TASK_NEXT_TOKEN = "test-token"
+    TEST_TASK_ROLE_ARN = "test-task-role-arn"
 
     TEST_TASK_DEFINITION = "test-task-definition"
     TEST_TASK_DEFINITION_ARN = "test-task-definition-arn"
@@ -110,6 +111,7 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_SUBNETS,
             cpu=self.TEST_CPU,
             memory=self.TEST_MEMORY,
+            task_role_arn=self.TEST_TASK_ROLE_ARN,
         )
         # Assert
         self.assertEqual(task, expected_task)
@@ -134,6 +136,7 @@ class TestECSGateway(unittest.TestCase):
                 ],
                 "cpu": str(cpu_response),
                 "memory": str(memory_response),
+                "taskRoleArn": self.TEST_TASK_ROLE_ARN,
             },
         )
 


### PR DESCRIPTION
Summary: This change updates the ECS Gateway to accept an overrides argument and includes the overrides when calling into the ECS API to run a task.

Reviewed By: zhuang-93

Differential Revision: D44098109

