### PR TITLE
Update ContainerService to accept a permissions arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
 - ECS Gateway Run Task support for overriding task role
+- Container Service Create Instance support for Container permission configuration
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
+- Update Container Instance to include Container Permission, when configured
 ### Removed
 
 ## [0.5.0] - 2023-3-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
+- ECS Gateway Run Task support for overriding task role
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 ### Removed

--- a/fbpcp/entity/container_instance.py
+++ b/fbpcp/entity/container_instance.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Optional
 
 from dataclasses_json import dataclass_json
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 
 
 class ContainerInstanceStatus(Enum):
@@ -29,3 +30,4 @@ class ContainerInstance:
     cpu: Optional[int] = None  # Number of vCPU
     memory: Optional[int] = None  # Memory in GB
     exit_code: Optional[int] = None
+    permission: Optional[ContainerPermissionConfig] = None

--- a/fbpcp/entity/container_permission.py
+++ b/fbpcp/entity/container_permission.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class ContainerPermissionConfig:
+    role_id: str

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -14,6 +14,7 @@ from fbpcp.entity.cloud_cost import CloudCost, CloudCostItem
 from fbpcp.entity.cluster_instance import Cluster, ClusterStatus
 from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.firewall_ruleset import FirewallRule, FirewallRuleset
 from fbpcp.entity.policy_statement import PolicyStatement
 from fbpcp.entity.route_table import (
@@ -74,6 +75,15 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
         status = ContainerInstanceStatus.UNKNOWN
     vcpu = map_unit_to_vcpu(task["cpu"]) if "cpu" in task else None
     memory_in_gb = map_mb_to_gb(task["memory"]) if "memory" in task else None
+
+    container_permission = None
+
+    overrides = task.get("overrides")
+    if overrides:
+        task_role_arn = overrides.get("taskRoleArn")
+        if task_role_arn:
+            container_permission = ContainerPermissionConfig(task_role_arn)
+
     return ContainerInstance(
         instance_id=task["taskArn"],
         ip_address=ip_v4,
@@ -81,6 +91,7 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
         cpu=vcpu,
         memory=memory_in_gb,
         exit_code=container.get("exitCode"),
+        permission=container_permission,
     )
 
 

--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Union
 from fbpcp.entity.cluster_instance import Cluster
 
 from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 
@@ -36,6 +37,7 @@ class ContainerService(abc.ABC):
         cmd: str,
         env_vars: Optional[Dict[str, str]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> ContainerInstance:
         pass
 
@@ -46,6 +48,7 @@ class ContainerService(abc.ABC):
         cmds: List[str],
         env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         pass
 

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -21,6 +21,7 @@ class TestECSGateway(unittest.TestCase):
     TEST_TASK_ARN_2 = "test-task-arn-2"
     TEST_TASK_ARN_DNE = "test-task-arn-dne"
     TEST_TASK_NEXT_TOKEN = "test-token"
+    TEST_TASK_ROLE_ARN = "test-task-role-arn"
 
     TEST_TASK_DEFINITION = "test-task-definition"
     TEST_TASK_DEFINITION_ARN = "test-task-definition-arn"
@@ -110,6 +111,7 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_SUBNETS,
             cpu=self.TEST_CPU,
             memory=self.TEST_MEMORY,
+            task_role_arn=self.TEST_TASK_ROLE_ARN,
         )
         # Assert
         self.assertEqual(task, expected_task)
@@ -134,6 +136,7 @@ class TestECSGateway(unittest.TestCase):
                 ],
                 "cpu": str(cpu_response),
                 "memory": str(memory_response),
+                "taskRoleArn": self.TEST_TASK_ROLE_ARN,
             },
         )
 


### PR DESCRIPTION
Summary:
This change updates the Container Service to take a permissions argument when creating instances. This argument will configure the permission for the container created. The Container Instance returned from Container Service will also now include a property describing the container's permissions, when overridden from the default.

The permissions will be used in a later diff to configure permissions allowing the container to access TLS secret/private key, when the feature is enabled.

Currently, the permission argument will only drive behavior for AWS-ECS Container Service.

Differential Revision: D44140791

