### PR TITLE
Update OneDocker Service to accept container permissions arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
 - ECS Gateway Run Task support for overriding task role
+- Container Service Create Instance support for Container permission configuration
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
+- Update Container Instance to include Container Permission, when configured
 ### Removed
 
 ## [0.5.0] - 2023-3-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add LimitExceeded Exception as PcpError
 - ECS Gateway Run Task support for overriding task role
 - Container Service Create Instance support for Container permission configuration
+- OneDocker Service Start Containers support for Container permission configuration
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 - Update Container Instance to include Container Permission, when configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
+- ECS Gateway Run Task support for overriding task role
 ### Changed
 - Refactor OneDocker CLI and OneDocker Service to support OneDocker E2E testing framework
 ### Removed

--- a/fbpcp/entity/container_instance.py
+++ b/fbpcp/entity/container_instance.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Optional
 
 from dataclasses_json import dataclass_json
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 
 
 class ContainerInstanceStatus(Enum):
@@ -29,3 +30,4 @@ class ContainerInstance:
     cpu: Optional[int] = None  # Number of vCPU
     memory: Optional[int] = None  # Memory in GB
     exit_code: Optional[int] = None
+    permission: Optional[ContainerPermissionConfig] = None

--- a/fbpcp/entity/container_permission.py
+++ b/fbpcp/entity/container_permission.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class ContainerPermissionConfig:
+    role_id: str

--- a/fbpcp/mapper/aws.py
+++ b/fbpcp/mapper/aws.py
@@ -14,6 +14,7 @@ from fbpcp.entity.cloud_cost import CloudCost, CloudCostItem
 from fbpcp.entity.cluster_instance import Cluster, ClusterStatus
 from fbpcp.entity.container_definition import ContainerDefinition
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.firewall_ruleset import FirewallRule, FirewallRuleset
 from fbpcp.entity.policy_statement import PolicyStatement
 from fbpcp.entity.route_table import (
@@ -74,6 +75,15 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
         status = ContainerInstanceStatus.UNKNOWN
     vcpu = map_unit_to_vcpu(task["cpu"]) if "cpu" in task else None
     memory_in_gb = map_mb_to_gb(task["memory"]) if "memory" in task else None
+
+    container_permission = None
+
+    overrides = task.get("overrides")
+    if overrides:
+        task_role_arn = overrides.get("taskRoleArn")
+        if task_role_arn:
+            container_permission = ContainerPermissionConfig(task_role_arn)
+
     return ContainerInstance(
         instance_id=task["taskArn"],
         ip_address=ip_v4,
@@ -81,6 +91,7 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
         cpu=vcpu,
         memory=memory_in_gb,
         exit_code=container.get("exitCode"),
+        permission=container_permission,
     )
 
 

--- a/fbpcp/service/container.py
+++ b/fbpcp/service/container.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Union
 from fbpcp.entity.cluster_instance import Cluster
 
 from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 
@@ -36,6 +37,7 @@ class ContainerService(abc.ABC):
         cmd: str,
         env_vars: Optional[Dict[str, str]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> ContainerInstance:
         pass
 
@@ -46,6 +48,7 @@ class ContainerService(abc.ABC):
         cmds: List[str],
         env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         pass
 

--- a/fbpcp/service/onedocker.py
+++ b/fbpcp/service/onedocker.py
@@ -13,6 +13,7 @@ from typing import Dict, Final, List, Optional, Union
 from fbpcp.decorator.metrics import duration_time, error_counter, request_counter
 from fbpcp.entity.certificate_request import CertificateRequest
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 from fbpcp.metrics.emitter import MetricsEmitter
@@ -91,6 +92,7 @@ class OneDockerService(MetricsGetter):
         certificate_request: Optional[CertificateRequest] = None,
         opa_workflow_path: Optional[str] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> ContainerInstance:
         """
         This function statrts one container for running MPC games.
@@ -108,6 +110,7 @@ class OneDockerService(MetricsGetter):
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
             opa_workflow_path:  A string that denotes the path to a specified opa workflow. Supported Path type: local.
+            permission:         A configuration which describes the container permissions
 
         """
         return self.start_containers(
@@ -121,6 +124,7 @@ class OneDockerService(MetricsGetter):
             certificate_request=certificate_request,
             opa_workflow_path=opa_workflow_path,
             container_type=container_type,
+            permission=permission,
         )[0]
 
     @error_counter(METRICS_START_CONTAINERS_ERROR_COUNT)
@@ -138,6 +142,7 @@ class OneDockerService(MetricsGetter):
         certificate_request: Optional[CertificateRequest] = None,
         opa_workflow_path: Optional[str] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         """Spin up cloud containers according to command arg list.
 
@@ -154,6 +159,7 @@ class OneDockerService(MetricsGetter):
             tag:                Tag for docker containers
             certificate_request: An optional instance of CertificateRequest that contains the parameters required to create a TLS certificate
             opa_workflow_path:  A string that denotes the path to a specified opa workflow. Supported Path type: local.
+            permission:         A configuration which describes the container permissions
 
         Returns:
             A list of the containers that were successfuly started
@@ -192,6 +198,7 @@ class OneDockerService(MetricsGetter):
             cmds=cmds,
             env_vars=env_vars,
             container_type=container_type,
+            permission=permission,
         )
         if containers:
             self.logger.info(

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -21,6 +21,7 @@ class TestECSGateway(unittest.TestCase):
     TEST_TASK_ARN_2 = "test-task-arn-2"
     TEST_TASK_ARN_DNE = "test-task-arn-dne"
     TEST_TASK_NEXT_TOKEN = "test-token"
+    TEST_TASK_ROLE_ARN = "test-task-role-arn"
 
     TEST_TASK_DEFINITION = "test-task-definition"
     TEST_TASK_DEFINITION_ARN = "test-task-definition-arn"
@@ -110,6 +111,7 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_SUBNETS,
             cpu=self.TEST_CPU,
             memory=self.TEST_MEMORY,
+            task_role_arn=self.TEST_TASK_ROLE_ARN,
         )
         # Assert
         self.assertEqual(task, expected_task)
@@ -134,6 +136,7 @@ class TestECSGateway(unittest.TestCase):
                 ],
                 "cpu": str(cpu_response),
                 "memory": str(memory_response),
+                "taskRoleArn": self.TEST_TASK_ROLE_ARN,
             },
         )
 

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -13,6 +13,7 @@ from unittest.mock import ANY, call, MagicMock, patch
 from fbpcp.entity.certificate_request import CertificateRequest, KeyAlgorithm
 from fbpcp.entity.cloud_provider import CloudProvider
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType, ContainerTypeConfig
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.onedocker import (
@@ -46,6 +47,7 @@ TEST_CONTAINER_CONFIG: ContainerTypeConfig = ContainerTypeConfig.get_config(
     TEST_CLOUD_PROVIDER, TEST_CONTAINER_TYPE
 )
 TEST_OPA_WORKFLOW_PATH = "/folder/file.json"
+TEST_PERMISSION: ContainerPermissionConfig = ContainerPermissionConfig("test-role-id")
 
 
 class TestOneDockerServiceSync(unittest.TestCase):
@@ -72,9 +74,17 @@ class TestOneDockerServiceSync(unittest.TestCase):
             certificate_request=None,
             container_type=TEST_CONTAINER_TYPE,
             opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
+            permission=TEST_PERMISSION,
         )
         # Assert
         self.assertEqual(returned_container_info, mocked_container_info)
+        self.container_svc.create_instances.assert_called_with(
+            container_definition=TEST_TASK_DEF,
+            cmds=ANY,
+            env_vars=ANY,
+            container_type=TEST_CONTAINER_TYPE,
+            permission=TEST_PERMISSION,
+        )
 
     def test_start_containers(self):
         # Arrange
@@ -131,6 +141,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             certificate_request=test_cert_request,
             container_type=TEST_CONTAINER_TYPE,
             opa_workflow_path=TEST_OPA_WORKFLOW_PATH,
+            permission=TEST_PERMISSION,
         )
 
         # Assert
@@ -167,6 +178,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
             cmds=expected_cmd,
             env_vars=TEST_ENV_VARS_LIST,
             container_type=TEST_CONTAINER_TYPE,
+            permission=None,
         )
 
     def test_start_containers_throw_with_invalid_env_var_list(self):
@@ -180,6 +192,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 env_vars=[TEST_ENV_VARS],
                 timeout=TEST_TIMEOUT,
                 container_type=TEST_CONTAINER_TYPE,
+                permission=None,
             )
         with self.assertRaises(ValueError):
             self.onedocker_svc.start_containers(
@@ -190,6 +203,7 @@ class TestOneDockerServiceSync(unittest.TestCase):
                 env_vars=[],
                 timeout=TEST_TIMEOUT,
                 container_type=TEST_CONTAINER_TYPE,
+                permission=None,
             )
 
     def test_get_cmd(self):


### PR DESCRIPTION
Summary:
This change updates OneDocker Service to accept an argument for configuration of container permissions and pass that forward to the Container Service when creating new containers.

This will be used by OneDocker Service callers to set up TLS-related permissions when the feature is enabled.

Differential Revision: D44433607

