### PR TITLE
Upgrade Ubuntu image for PCP package release workflow

### DIFF
--- a/.github/workflows/publish_project.yml
+++ b/.github/workflows/publish_project.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-package-version:
     name: Check Package Version
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       version_check: ${{ steps.version_check.outputs.version_check }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   build-n-publish:
     name: Build and publish distributions to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: check-package-version
     if : needs.check-package-version.outputs.version_check == 'higher'
     steps:


### PR DESCRIPTION
Summary:
This change updates the Ubuntu image used to build a new PyPI package version of PCP from `ubuntu-18.04` to `ubuntu-latest`. This matches the OS version used for other Github build actions.

The workflow recently started failing as [GitHub deprecated the 18.04 version](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/) of Ubuntu for Actions starting in 2023 and this took full effect at the end of March.

We detected this when a recent Action workflow got stuck in the sttage: "Waiting for a runner to pick up this job...": https://github.com/facebookresearch/fbpcp/actions/runs/4613539824/jobs/8155625349

Differential Revision: D44707822

