### PR TITLE
Revert "Release fbpcp to 0.6.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-### Changed
-### Removed
-
-## [0.6.0] - 2023-04-04
-### Added
 - Add Insights Service
 - Add LimitExceeded Exception as PcpError
 - ECS Gateway Run Task support for overriding task role

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.6.0",
+    version="0.5.0",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
The [release commit](https://github.com/facebookresearch/fbpcp/pull/512) that we are reverting here failed to complete its triggered [package release workflow](https://github.com/facebookresearch/fbpcp/actions/runs/4613539824) because the OS used in the Github Action workflow file had been deprecated at the end of March.

We have since [fixed the workflow file](https://github.com/facebookresearch/fbpcp/pull/513) but re-running the failed workflow still uses the original workflow definition file. To release, a new workflow must be triggered by committing a new change that touches `setup.py`

To do this, we will back out the release commit with this diff. In a subsequent diff, we will reapply the release commit which will trigger the release workflow again.

Reviewed By: yutong-w

Differential Revision: D44712355

