### PR TITLE
Integrate InsightsService with OneDockerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Integrate InsightsService with OneDockerService
 ### Changed
 ### Removed
 


### PR DESCRIPTION
Summary: This is to add InsightsService on OneDockerService start_containers and waiting_for_pending_containers API calls.

Differential Revision: D44792264

