### PR TITLE
Create StoppedMetadata class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Integrate InsightsService with OneDockerService
+- Add ContainerStoppedMetadata
 ### Changed
 ### Removed
 

--- a/fbpcp/entity/container_instance.py
+++ b/fbpcp/entity/container_instance.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Optional
 
 from dataclasses_json import dataclass_json
+from fbpcp.entity.container_metadata import ContainerStoppedMetadata
 from fbpcp.entity.container_permission import ContainerPermissionConfig
 
 
@@ -31,3 +32,4 @@ class ContainerInstance:
     memory: Optional[int] = None  # Memory in GB
     exit_code: Optional[int] = None
     permission: Optional[ContainerPermissionConfig] = None
+    stopped_metadata: Optional[ContainerStoppedMetadata] = None

--- a/fbpcp/entity/container_metadata.py
+++ b/fbpcp/entity/container_metadata.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ContainerStoppedMetadata:
+    stopped_at: str
+    stop_code: str
+    stopped_reason: str


### PR DESCRIPTION
Summary:
Added `StoppedMetadata` class in order to provide more insights to improve the debugging efficiency.

For this task, we mainly focus on the metadata when a container stopped (normally or unexpectedly). `StoppedMetadata` will be an attribute of `ContainerInstance`.

Reviewed By: zhuang-93

Differential Revision: D44940312

