### PR TITLE
Del `(object)` from 10 inc measurement/ncs_ca_plus/reach_analysis.py

### DIFF
--- a/fbpcp/gateway/s3.py
+++ b/fbpcp/gateway/s3.py
@@ -159,7 +159,7 @@ class S3Gateway(AWSGateway):
             response["RestrictPublicBuckets"],
         )
 
-    class ProgressPercentage(object):
+    class ProgressPercentage:
         def __init__(self, file_name: str, file_size: int) -> None:
             self._progressbar: tqdm = tqdm(total=file_size, desc=file_name)
 


### PR DESCRIPTION
Summary: Python3 makes the use of `(object)` in class inheritance unnecessary. Let's modernize our code by eliminating this.

Reviewed By: meyering

Differential Revision: D48957859


