### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/publish_project.yml
+++ b/.github/workflows/publish_project.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Get version check output
       id: version_check
       run: >-
-       echo "::set-output name=version_check::$(python3 ./scripts/compare_package_version.py | tail -1)"
+       echo "version_check=$(python3 ./scripts/compare_package_version.py | tail -1)" >> $GITHUB_OUTPUT
 
   build-n-publish:
     name: Build and publish distributions to PyPI


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter