### PR TITLE
Fix FBPCP pyre action workflow (pin to official latest pyre-check release version in github action)

### DIFF
--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -24,7 +24,7 @@ jobs:
           python3 -m venv env
           source env/bin/activate
           python3 -m pip install .
-          python3 -m pip install pyre-check-nightly~=0.0.10
+          python3 -m pip install pyre-check==0.9.19
       - name: Run Pyre
         run: |
           source env/bin/activate


### PR DESCRIPTION
Summary:
FBPCP pyre action workflow has been broken (https://github.com/facebookresearch/fbpcp/actions/workflows/pyre.yml) since this change
https://github.com/facebook/pyre-check/commit/d3164ae128b64dd16db47cd8fee15194c8388671.

FBPCP takes pyre-check-nightly which is a beta version of pyre-check that is not compatible with Python3.8 (where our OSS is using).  To fix this, let’s pin to latest offical pyre-check latest version pyre-check==0.9.19.

https://pypi.org/project/pyre-check/#history

Differential Revision: D57057873


