### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.6.3]
+### Added
+### Changed
+- Bump tqdm version.
+### Removed
+
 ## [0.6.2]
 ### Added
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.6.2",
+    version="0.6.3",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary: We recently (D57063468) updated the version of tqdm as part of a security fix. But now we need to bump the version number so we can use this version in dependent code

Differential Revision: D57498448


