### PR TITLE
bump fbpcp version 0.6.4 due to urllib3 version bump to 1.26.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.6.4]
+### Added
+### Changed
+- Bump urllib3 version to 1.26.19.
+### Removed
+
 ## [0.6.3]
 ### Added
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcp",
-    version="0.6.3",
+    version="0.6.4",
     description="Facebook Private Computation Platform",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
In D58744164, we bumped urllib3 version to 1.26.19.

As a result we also need to bump fbpcp version to 0.6.4.

Reviewed By: tyurek

Differential Revision: D58752858
